### PR TITLE
Step1 - 레거시 코드 리팩터링

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,26 @@
-# 학습 관리 시스템(Learning Management System)
-## 진행 방법
-* 학습 관리 시스템의 수강신청 요구사항을 파악한다.
-* 요구사항에 대한 구현을 완료한 후 자신의 github 아이디에 해당하는 브랜치에 Pull Request(이하 PR)를 통해 코드 리뷰 요청을 한다.
-* 코드 리뷰 피드백에 대한 개선 작업을 하고 다시 PUSH한다.
-* 모든 피드백을 완료하면 다음 단계를 도전하고 앞의 과정을 반복한다.
+# 수강신청 미션
 
-## 온라인 코드 리뷰 과정
-* [텍스트와 이미지로 살펴보는 온라인 코드 리뷰 과정](https://github.com/next-step/nextstep-docs/tree/master/codereview)
+---
+## Step1 - 레거시 코드 리팩터링
+### 요구 사항
+* 질문 삭제하기 요구사항
+    * 질문 데이터를 완전히 삭제하는 것이 아니라 데이터의 상태를 삭제 상태(deleted - boolean type)로 변경한다.
+    * 로그인 사용자와 질문한 사람이 같은 경우 삭제 가능하다.
+    * 답변이 없는 경우 삭제가 가능하다.
+    * 질문자와 답변글의 모든 답변자가 같은 경우 삭제가 가능하다.
+    * 질문을 삭제할 때 답변 또한 삭제해야 하며, 답변의 삭제 또한 삭제 상태(deleted)를 변경한다.
+    * 질문자와 답변자가 다른 경우 답변을 삭제할 수 없다.
+    * 질문과 답변 삭제 이력에 대한 정보를 DeleteHistory를 활용해 남긴다.
+
+* 리팩터링 요구사항
+    * nextstep.qna.service.QnaService의 deleteQuestion()는 앞의 질문 삭제 기능을 구현한 코드이다. 이 메소드는 단위 테스트하기 어려운 코드와 단위 테스트 가능한 코드가 섞여 있다.
+    * QnaService의 deleteQuestion() 메서드에 단위 테스트 가능한 코드(핵심 비지니스 로직)를 도메인 모델 객체에 구현한다.
+    * QnaService의 비지니스 로직을 도메인 모델로 이동하는 리팩터링을 진행할 때 TDD로 구현한다.
+    * QnaService의 deleteQuestion() 메서드에 대한 단위 테스트는 src/test/java 폴더 nextstep.qna.service.QnaServiceTest이다. 도메인 모델로 로직을 이동한 후에도 QnaServiceTest의 모든 테스트는 통과해야 한다.
+
+* 구현 내용
+- [ ] Question 클래스에 delete 메서드를 추가
+    - [ ] 질문 삭제 권한 확인 기능
+    - [ ] 다른 사람이 쓴 답변 확인 기능
+    - [ ] DeleteHistory 생성 후 반환 기능
+- [ ] QnAService 클래스 내 deleteQuestion 메서드 비즈니스 로직 코드 삭제

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@
 * 구현 내용
 - [ ] Question 클래스에 delete 메서드를 추가
     - [X] 질문 삭제 권한 확인 기능
-    - [ ] 다른 사람이 쓴 답변 확인 기능
+    - [X] 다른 사람이 쓴 답변 확인 기능
     - [ ] DeleteHistory 생성 후 반환 기능
 - [ ] QnAService 클래스 내 deleteQuestion 메서드 비즈니스 로직 코드 삭제

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
     * QnaService의 deleteQuestion() 메서드에 대한 단위 테스트는 src/test/java 폴더 nextstep.qna.service.QnaServiceTest이다. 도메인 모델로 로직을 이동한 후에도 QnaServiceTest의 모든 테스트는 통과해야 한다.
 
 * 구현 내용
-- [ ] Question 클래스에 delete 메서드를 추가
+- [X] Question 클래스에 delete 메서드를 추가
     - [X] 질문 삭제 권한 확인 기능
     - [X] 다른 사람이 쓴 답변 확인 기능
-    - [ ] DeleteHistory 생성 후 반환 기능
-- [ ] QnAService 클래스 내 deleteQuestion 메서드 비즈니스 로직 코드 삭제
+    - [X] DeleteHistory 생성 후 반환 기능
+- [X] QnAService 클래스 내 deleteQuestion 메서드 비즈니스 로직 코드 삭제

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 * 구현 내용
 - [ ] Question 클래스에 delete 메서드를 추가
-    - [ ] 질문 삭제 권한 확인 기능
+    - [X] 질문 삭제 권한 확인 기능
     - [ ] 다른 사람이 쓴 답변 확인 기능
     - [ ] DeleteHistory 생성 후 반환 기능
 - [ ] QnAService 클래스 내 deleteQuestion 메서드 비즈니스 로직 코드 삭제

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -72,6 +72,11 @@ public class Answer {
         this.question = question;
     }
 
+    public DeleteHistory delete() {
+        deleted = true;
+        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
+    }
+
     @Override
     public String toString() {
         return "Answer [id=" + getId() + ", writer=" + writer + ", contents=" + contents + "]";

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -6,6 +6,7 @@ import nextstep.users.domain.NsUser;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Answers {
 
@@ -26,14 +27,9 @@ public class Answers {
     public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
         isDeletable(loginUser);
 
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-
-        return deleteHistories;
+        return answers.stream()
+                .map(Answer::delete)
+                .collect(Collectors.toList());
     }
 
     private void isDeletable(NsUser loginUser) throws CannotDeleteException {

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -1,0 +1,26 @@
+package nextstep.qna.domain;
+
+import nextstep.qna.CannotDeleteException;
+import nextstep.users.domain.NsUser;
+
+import java.util.List;
+
+public class Answers {
+
+    private final List<Answer> answers;
+
+    public Answers(List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    public void isDeletable(NsUser loginUser) throws CannotDeleteException {
+        if (hasOtherAnswerUser(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+    }
+
+    private boolean hasOtherAnswerUser(NsUser loginUser) {
+        return answers.stream()
+                .anyMatch(answer -> answer.isOwner(loginUser));
+    }
+}

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -3,6 +3,8 @@ package nextstep.qna.domain;
 import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUser;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public class Answers {
@@ -13,7 +15,28 @@ public class Answers {
         this.answers = answers;
     }
 
-    public void isDeletable(NsUser loginUser) throws CannotDeleteException {
+    public Answers() {
+        this(new ArrayList<>());
+    }
+
+    public static Answers create() {
+        return new Answers();
+    }
+
+    public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
+        isDeletable(loginUser);
+
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+
+        for (Answer answer : answers) {
+            answer.setDeleted(true);
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+        }
+
+        return deleteHistories;
+    }
+
+    private void isDeletable(NsUser loginUser) throws CannotDeleteException {
         if (hasOtherAnswerUser(loginUser)) {
             throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
         }
@@ -21,6 +44,11 @@ public class Answers {
 
     private boolean hasOtherAnswerUser(NsUser loginUser) {
         return answers.stream()
-                .anyMatch(answer -> answer.isOwner(loginUser));
+                .anyMatch(answer -> !answer.isOwner(loginUser));
+    }
+
+    public Answers add(Answer answer) {
+        answers.add(answer);
+        return new Answers(answers);
     }
 }

--- a/src/main/java/nextstep/qna/domain/DeleteHistory.java
+++ b/src/main/java/nextstep/qna/domain/DeleteHistory.java
@@ -26,6 +26,10 @@ public class DeleteHistory {
         this.createdDate = createdDate;
     }
 
+    public static DeleteHistory createQuestionDeleteHistory(Long id, NsUser writer) {
+        return new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -61,7 +61,7 @@ public class Question {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         deleted = true;
 
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
+        deleteHistories.add(DeleteHistory.createQuestionDeleteHistory(id, writer));
 
         deleteHistories.addAll(answers.delete(loginUser));
 

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -17,6 +17,7 @@ public class Question {
     private NsUser writer;
 
     private List<Answer> answers = new ArrayList<>();
+    private Answers answers2;
 
     private boolean deleted = false;
 
@@ -88,6 +89,13 @@ public class Question {
 
     public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
         hasAuthorization(loginUser);
+
+        answers2.isDeletable(loginUser);
+//        for (Answer answer : answers) {
+//            if (!answer.isOwner(loginUser)) {
+//                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+//            }
+//        }
 
         return null;
     }

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -1,5 +1,6 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;
@@ -83,6 +84,18 @@ public class Question {
 
     public List<Answer> getAnswers() {
         return answers;
+    }
+
+    public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
+        hasAuthorization(loginUser);
+
+        return null;
+    }
+
+    private void hasAuthorization(NsUser loginUser) throws CannotDeleteException {
+        if (!writer.equals(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
     }
 
     @Override

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -16,8 +16,7 @@ public class Question {
 
     private NsUser writer;
 
-    private List<Answer> answers = new ArrayList<>();
-    private Answers answers2;
+    private Answers answers = Answers.create();
 
     private boolean deleted = false;
 
@@ -43,24 +42,6 @@ public class Question {
         return id;
     }
 
-    public String getTitle() {
-        return title;
-    }
-
-    public Question setTitle(String title) {
-        this.title = title;
-        return this;
-    }
-
-    public String getContents() {
-        return contents;
-    }
-
-    public Question setContents(String contents) {
-        this.contents = contents;
-        return this;
-    }
-
     public NsUser getWriter() {
         return writer;
     }
@@ -70,34 +51,21 @@ public class Question {
         answers.add(answer);
     }
 
-    public boolean isOwner(NsUser loginUser) {
-        return writer.equals(loginUser);
-    }
-
-    public Question setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
-    }
-
     public boolean isDeleted() {
         return deleted;
-    }
-
-    public List<Answer> getAnswers() {
-        return answers;
     }
 
     public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
         hasAuthorization(loginUser);
 
-        answers2.isDeletable(loginUser);
-//        for (Answer answer : answers) {
-//            if (!answer.isOwner(loginUser)) {
-//                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-//            }
-//        }
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        deleted = true;
 
-        return null;
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
+
+        deleteHistories.addAll(answers.delete(loginUser));
+
+        return deleteHistories;
     }
 
     private void hasAuthorization(NsUser loginUser) throws CannotDeleteException {

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -30,24 +30,6 @@ public class QnAService {
                 .orElseThrow(NotFoundException::new);
 
         List<DeleteHistory> deleteHistories = question.delete(loginUser);
-//        if (!question.isOwner(loginUser)) {
-//            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-//        }
-
-//        List<Answer> answers = question.getAnswers();
-//        for (Answer answer : answers) {
-//            if (!answer.isOwner(loginUser)) {
-//                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-//            }
-//        }
-
-//        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-//        for (Answer answer : answers) {
-//            answer.setDeleted(true);
-//            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-//        }
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -25,10 +25,14 @@ public class QnAService {
 
     @Transactional
     public void deleteQuestion(NsUser loginUser, long questionId) throws CannotDeleteException {
-        Question question = questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
+        Question question = questionRepository
+                .findById(questionId)
+                .orElseThrow(NotFoundException::new);
+
+        question.delete(loginUser);
+//        if (!question.isOwner(loginUser)) {
+//            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+//        }
 
         List<Answer> answers = question.getAnswers();
         for (Answer answer : answers) {

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -29,25 +29,25 @@ public class QnAService {
                 .findById(questionId)
                 .orElseThrow(NotFoundException::new);
 
-        question.delete(loginUser);
+        List<DeleteHistory> deleteHistories = question.delete(loginUser);
 //        if (!question.isOwner(loginUser)) {
 //            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
 //        }
 
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
+//        List<Answer> answers = question.getAnswers();
+//        for (Answer answer : answers) {
+//            if (!answer.isOwner(loginUser)) {
+//                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+//            }
+//        }
 
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
+//        List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
+//        for (Answer answer : answers) {
+//            answer.setDeleted(true);
+//            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+//        }
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/test/java/nextstep/qna/domain/AnswersTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswersTest.java
@@ -5,6 +5,7 @@ import nextstep.users.domain.NsUserTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,6 +49,18 @@ public class AnswersTest {
                 .usingRecursiveComparison()
                 .isEqualTo(new Answers(new ArrayList<>(List.of(A1, A2))));
 
+    }
+
+    @Test
+    @DisplayName("삭제 테스트")
+    void deleteTest() {
+        DeleteHistory delete = A1.delete();
+
+        assertThat(A1.isDeleted())
+                .isTrue();
+
+        assertThat(delete)
+                .isEqualTo(new DeleteHistory(ContentType.ANSWER, null, NsUserTest.JAVAJIGI, LocalDateTime.now()));
     }
 
 }

--- a/src/test/java/nextstep/qna/domain/AnswersTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswersTest.java
@@ -5,8 +5,10 @@ import nextstep.users.domain.NsUserTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AnswersTest {
@@ -19,8 +21,33 @@ public class AnswersTest {
     void isDeletableTest() {
         Answers multiUserAnswers = new Answers(List.of(A1, A2));
 
-        assertThatThrownBy(() -> multiUserAnswers.isDeletable(NsUserTest.SANJIGI))
+        assertThatThrownBy(() -> multiUserAnswers.delete(NsUserTest.SANJIGI))
                 .isInstanceOf(CannotDeleteException.class);
+    }
+
+    @Test
+    @DisplayName("답변 삭제")
+    void deleteAnswersTest() throws CannotDeleteException {
+        Answers answers = new Answers(List.of(A1));
+
+        List<DeleteHistory> deleteHistories = answers.delete(NsUserTest.JAVAJIGI);
+
+        assertThat(deleteHistories)
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("답변 추가")
+    void addAnswer() {
+
+        Answers answers = new Answers(new ArrayList<>(List.of(A1)));
+
+        Answers newAnswers = answers.add(A2);
+
+        assertThat(newAnswers)
+                .usingRecursiveComparison()
+                .isEqualTo(new Answers(new ArrayList<>(List.of(A1, A2))));
+
     }
 
 }

--- a/src/test/java/nextstep/qna/domain/AnswersTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswersTest.java
@@ -1,0 +1,26 @@
+package nextstep.qna.domain;
+
+import nextstep.qna.CannotDeleteException;
+import nextstep.users.domain.NsUserTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AnswersTest {
+
+    public static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
+    public static final Answer A2 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+    @Test
+    @DisplayName("다른 사람이 쓴 답변이 있을 경우 삭제 불가")
+    void isDeletableTest() {
+        Answers multiUserAnswers = new Answers(List.of(A1, A2));
+
+        assertThatThrownBy(() -> multiUserAnswers.isDeletable(NsUserTest.SANJIGI))
+                .isInstanceOf(CannotDeleteException.class);
+    }
+
+}

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -1,11 +1,13 @@
 package nextstep.qna.domain;
 
 import nextstep.qna.CannotDeleteException;
-import nextstep.users.domain.NsUser;
 import nextstep.users.domain.NsUserTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class QuestionTest {
@@ -15,9 +17,16 @@ public class QuestionTest {
     @Test
     @DisplayName("질문 삭제 권한 확인")
     void isOwnerTest() {
-        NsUser sanjigi = NsUserTest.SANJIGI;
-
-        assertThatThrownBy(() -> Q1.delete(sanjigi))
+        assertThatThrownBy(() -> Q1.delete(NsUserTest.SANJIGI))
                 .isInstanceOf(CannotDeleteException.class);
+    }
+
+    @Test
+    @DisplayName("삭제 확인")
+    void deleteTest() throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = Q1.delete(NsUserTest.JAVAJIGI);
+
+        assertThat(deleteHistories)
+                .hasSize(1);
     }
 }

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -1,8 +1,23 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
+import nextstep.users.domain.NsUser;
 import nextstep.users.domain.NsUserTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class QuestionTest {
     public static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
     public static final Question Q2 = new Question(NsUserTest.SANJIGI, "title2", "contents2");
+
+    @Test
+    @DisplayName("질문 삭제 권한 확인")
+    void isOwnerTest() {
+        NsUser sanjigi = NsUserTest.SANJIGI;
+
+        assertThatThrownBy(() -> Q1.delete(sanjigi))
+                .isInstanceOf(CannotDeleteException.class);
+    }
 }

--- a/src/test/java/nextstep/qna/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/qna/service/QnaServiceTest.java
@@ -4,6 +4,7 @@ import nextstep.qna.CannotDeleteException;
 import nextstep.qna.domain.*;
 import nextstep.users.domain.NsUserTest;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;


### PR DESCRIPTION
### 구현 내용
- [X] Question 클래스에 delete 메서드를 추가
    - [X] 질문 삭제 권한 확인 기능
    - [X] 다른 사람이 쓴 답변 확인 기능
    - [X] DeleteHistory 생성 후 반환 기능
- [X] QnAService 클래스 내 deleteQuestion 메서드 비즈니스 로직 코드 삭제

---

안녕하세요~
이번 미션에서는 `QnAService 클래스`의 `deleteQuestion 메서드` 내 비즈니스 로직을 걷어내고 걷어낸 비즈니스 로직은 각 도메인에서 책임지도록 구현해보려 시도했습니다.
그 과정에서 `Question 클래스` 내부에 `List<Answers> 필드`는 `Answers` 클래스로 만들어봤습니다.
`List<DeleteHistory>` 필드도 동일하게 만들고 싶었으나.. 일단 수정해야 하는 범위가 너무 많아서 일단 이대로 리뷰 요청 드립니다.

구현하면서 질문이 있는데요, `List<DeleteHistory> 리스트`에 값을 추가할 때 생성자로 상수까지 추가하는 것은 바람직하지 않은것 같아 정적 팩토리 메서드를 사용하려 했습니다. `ContentType.QUESTION 타입`에서는 테스트 코드가 깨지지 않고 잘 동작하는데요, `Answer 클래스`에서도 동일하게 정적 팩토리 메서드를 사용했을 때에는 로직상 이상은 없는것 같은데 테스트 코드가 깨집니다. 아마도 `LocalDateTime.now()` 시점 차이 때문에 깨지는걸로 보이는데요, 어떻게 해결할 수 있을까요?

그럼 리뷰 잘 부탁드립니다~ 감사합니다!