### PR TITLE
step1 : 1단계 - 레거시 코드 리팩터링

### DIFF
--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -66,7 +66,7 @@ public class Answer {
     }
 
     public void delete(NsUser loginUser, List<DeleteHistory> deleteHistories) throws CannotDeleteException {
-        if (loginUser != this.writer) {
+        if (!loginUser.equals(this.writer)) {
             throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
         }
 

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -49,11 +49,6 @@ public class Answer {
         return id;
     }
 
-    public Answer setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
-    }
-
     public boolean isDeleted() {
         return deleted;
     }
@@ -64,10 +59,6 @@ public class Answer {
 
     public NsUser getWriter() {
         return writer;
-    }
-
-    public String getContents() {
-        return contents;
     }
 
     public void toQuestion(Question question) {

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -1,5 +1,7 @@
 package nextstep.qna.domain;
 
+import java.util.List;
+import nextstep.qna.CannotDeleteException;
 import nextstep.qna.NotFoundException;
 import nextstep.qna.UnAuthorizedException;
 import nextstep.users.domain.NsUser;
@@ -70,6 +72,15 @@ public class Answer {
 
     public void toQuestion(Question question) {
         this.question = question;
+    }
+
+    public void delete(NsUser loginUser, List<DeleteHistory> deleteHistories) throws CannotDeleteException {
+        if (loginUser != this.writer) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+
+        deleted = true;
+        deleteHistories.add(new DeleteHistory(ContentType.ANSWER, this.id, this.writer, LocalDateTime.now()));
     }
 
     @Override

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -68,16 +68,19 @@ public class Question {
         return answers;
     }
 
-    public void delete(NsUser loginUser, List<DeleteHistory> deleteHistories) throws CannotDeleteException {
-        if (loginUser != writer) {
+    public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
+        if (!loginUser.equals(writer)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
 
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, this.id, this.writer, LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.delete(loginUser, deleteHistories);
         }
         deleted = true;
+
+        return deleteHistories;
     }
 
     @Override

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -1,5 +1,6 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;
@@ -83,6 +84,18 @@ public class Question {
 
     public List<Answer> getAnswers() {
         return answers;
+    }
+
+    public void delete(NsUser loginUser, List<DeleteHistory> deleteHistories) throws CannotDeleteException {
+        if (loginUser != writer) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+
+        for (Answer answer : answers) {
+            answer.delete(loginUser, deleteHistories);
+        }
+        deleted = true;
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, this.id, this.writer, LocalDateTime.now()));
     }
 
     @Override

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -91,11 +91,11 @@ public class Question {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
 
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, this.id, this.writer, LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.delete(loginUser, deleteHistories);
         }
         deleted = true;
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, this.id, this.writer, LocalDateTime.now()));
     }
 
     @Override

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -46,19 +46,10 @@ public class Question {
         return title;
     }
 
-    public Question setTitle(String title) {
-        this.title = title;
-        return this;
-    }
-
     public String getContents() {
         return contents;
     }
 
-    public Question setContents(String contents) {
-        this.contents = contents;
-        return this;
-    }
 
     public NsUser getWriter() {
         return writer;
@@ -67,15 +58,6 @@ public class Question {
     public void addAnswer(Answer answer) {
         answer.toQuestion(this);
         answers.add(answer);
-    }
-
-    public boolean isOwner(NsUser loginUser) {
-        return writer.equals(loginUser);
-    }
-
-    public Question setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
     }
 
     public boolean isDeleted() {

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -26,9 +26,7 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(NsUser loginUser, long questionId) throws CannotDeleteException {
         Question question = questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-
-        question.delete(loginUser, deleteHistories);
+        List<DeleteHistory> deleteHistories = question.delete(loginUser);
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -26,24 +26,9 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(NsUser loginUser, long questionId) throws CannotDeleteException {
         Question question = questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
+
+        question.delete(loginUser, deleteHistories);
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/test/java/nextstep/qna/domain/AnswerTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswerTest.java
@@ -1,8 +1,48 @@
 package nextstep.qna.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import nextstep.qna.CannotDeleteException;
+import nextstep.users.domain.NsUser;
 import nextstep.users.domain.NsUserTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AnswerTest {
     public static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+    private NsUser user;
+    private Question question;
+    private Answer answer;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        user = NsUserTest.JAVAJIGI;
+        question = new Question(1L, user, "title1", "contents1");
+        answer = new Answer(11L, user, question, "Answers Contents1");
+    }
+
+    @Test
+    void delete_성공() throws Exception {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        answer.delete(user, deleteHistories);
+
+        Assertions.assertTrue(answer.isDeleted());
+        assertThat(deleteHistories).hasSize(1);
+    }
+
+    @Test
+    void delete_답변자와_일치하지_않으면_실패() throws Exception {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        NsUser otherUser = NsUserTest.SANJIGI;
+
+        assertThatThrownBy(() -> answer.delete(otherUser, deleteHistories))
+            .isInstanceOf(CannotDeleteException.class)
+            .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+    }
 }

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -18,20 +18,18 @@ public class QuestionTest {
 
   private NsUser user;
   private Question question;
-  private List<DeleteHistory> deleteHistories;
 
   @BeforeEach
   public void setUp() throws Exception {
     user = NsUserTest.JAVAJIGI;
     question = new Question(1L, user, "title1", "contents1");
-    deleteHistories = new ArrayList<>();
   }
 
 
   @Test
   void delete_성공() throws Exception {
     question.addAnswer(AnswerTest.A1);
-    question.delete(user, deleteHistories);
+    List<DeleteHistory> deleteHistories = question.delete(user);
 
     // JPA를 사용하면 getter를 열어두는 경우가 많기 때문에 getter는 도메인에서 제거하지 않고 남겨놓음
     // 대신 테스트에서만 사용한다고 팀에서 약속했다고 가정
@@ -51,7 +49,7 @@ public class QuestionTest {
   void delete_로그인_사용자와_질문한_사람이_다르면_실패() throws Exception {
     NsUser otherUser = NsUserTest.SANJIGI;
 
-    Assertions.assertThatThrownBy(() -> question.delete(otherUser, deleteHistories))
+    Assertions.assertThatThrownBy(() -> question.delete(otherUser))
         .isInstanceOf(CannotDeleteException.class)
         .hasMessageContaining("질문을 삭제할 권한이 없습니다.");
   }
@@ -60,7 +58,7 @@ public class QuestionTest {
   void delete_다른_사용자의_답변이_존재하면_삭제가_불가능() throws Exception {
     question.addAnswer(AnswerTest.A2);
 
-    Assertions.assertThatThrownBy(() -> question.delete(user, deleteHistories))
+    Assertions.assertThatThrownBy(() -> question.delete(user))
         .isInstanceOf(CannotDeleteException.class)
         .hasMessageContaining("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
   }
@@ -72,7 +70,7 @@ public class QuestionTest {
     question.addAnswer(AnswerTest.A1);
 
     // when
-    question.delete(user, deleteHistories);
+    List<DeleteHistory> deleteHistories = question.delete(user);
 
     // then
     assertTrue(question.isDeleted());
@@ -90,7 +88,7 @@ public class QuestionTest {
     question.addAnswer(AnswerTest.A1);
     question.addAnswer(AnswerTest.A2);
 
-    Assertions.assertThatThrownBy(() -> question.delete(user, deleteHistories))
+    Assertions.assertThatThrownBy(() -> question.delete(user))
         .isInstanceOf(CannotDeleteException.class)
         .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
   }

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -1,8 +1,97 @@
 package nextstep.qna.domain;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import nextstep.qna.CannotDeleteException;
+import nextstep.users.domain.NsUser;
 import nextstep.users.domain.NsUserTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class QuestionTest {
-    public static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
-    public static final Question Q2 = new Question(NsUserTest.SANJIGI, "title2", "contents2");
+
+  public static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
+  public static final Question Q2 = new Question(NsUserTest.SANJIGI, "title2", "contents2");
+
+  private NsUser user;
+  private Question question;
+  private List<DeleteHistory> deleteHistories;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    user = NsUserTest.JAVAJIGI;
+    question = new Question(1L, user, "title1", "contents1");
+    deleteHistories = new ArrayList<>();
+  }
+
+
+  @Test
+  void delete_성공() throws Exception {
+    question.addAnswer(AnswerTest.A1);
+    question.delete(user, deleteHistories);
+
+    // JPA를 사용하면 getter를 열어두는 경우가 많기 때문에 getter는 도메인에서 제거하지 않고 남겨놓음
+    // 대신 테스트에서만 사용한다고 팀에서 약속했다고 가정
+    assertTrue(question.isDeleted());
+
+    // 고민 포인트 1. answer가 deleted되었는지에 대한 확인은 Question의 메서드에서 확인해야 하는가?
+    // 찬 : question.delete()가 기대하는 바는 answer들 또한 삭제되는 일이다
+    // 반 : 이는 answer에서 처리해야 할 영역이다. answer의 동작이 변경될 경우 이 테스트 코드는 영향을 받는다
+    for (Answer answer : question.getAnswers()) {
+      assertTrue(answer.isDeleted());
+    }
+    Assertions.assertThat(deleteHistories)
+        .hasSize(2);
+  }
+
+  @Test
+  void delete_로그인_사용자와_질문한_사람이_다르면_실패() throws Exception {
+    NsUser otherUser = NsUserTest.SANJIGI;
+
+    Assertions.assertThatThrownBy(() -> question.delete(otherUser, deleteHistories))
+        .isInstanceOf(CannotDeleteException.class)
+        .hasMessageContaining("질문을 삭제할 권한이 없습니다.");
+  }
+
+  @Test
+  void delete_다른_사용자의_답변이_존재하면_삭제가_불가능() throws Exception {
+    question.addAnswer(AnswerTest.A2);
+
+    Assertions.assertThatThrownBy(() -> question.delete(user, deleteHistories))
+        .isInstanceOf(CannotDeleteException.class)
+        .hasMessageContaining("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+  }
+
+  @Test
+  void delete_같은_사용자의_답변만_존재하면_삭제_가능() throws Exception {
+    // given
+    question.addAnswer(AnswerTest.A1);
+    question.addAnswer(AnswerTest.A1);
+
+    // when
+    question.delete(user, deleteHistories);
+
+    // then
+    assertTrue(question.isDeleted());
+
+    for (Answer answer : question.getAnswers()) {
+      assertTrue(answer.isDeleted());
+    }
+    Assertions.assertThat(deleteHistories)
+        .hasSize(3);
+  }
+
+  @Test
+  void delete_다른_사용자의_답변이_하나라도_존재하면_삭제_불가능() throws Exception {
+    question.addAnswer(AnswerTest.A1);
+    question.addAnswer(AnswerTest.A1);
+    question.addAnswer(AnswerTest.A2);
+
+    Assertions.assertThatThrownBy(() -> question.delete(user, deleteHistories))
+        .isInstanceOf(CannotDeleteException.class)
+        .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+  }
 }


### PR DESCRIPTION
안녕하세요! 늦었지만 코드 리뷰 부탁드립니다!

과제를 수행하면서 고려했던 점, 궁금한 점들은 다음과 같습니다.

getter는 열어둔다 : JPA를 사용하면 getter를 사용하게 되고, delete 메서드가 command이기 때문에 상태에 대해 테스트하기 어려워 getter는 남기기로 결정했습니다. 단, 테스트에서만 사용한다고 팀에서 약속한다고 가정합니다.
=> 만약 getter가 적당하지 않다고 판단된다면 void를 리턴하는 command에서는 상태에 대해서 어떻게 테스트할 수 있을까요?

question의 delete 메서드에 대해서 테스트할 때, answer에 대해서도 테스트했는데 이게 옳은 방법인지 궁금합니다. delete 메서드가 기대하는 동작은 question / answer에 대해 deleted = true하는 동작과, deleteHistory를 더하는 동작이라 함께 테스트했습니다. 그러나, question의 테스트지만 answer에 대해서 의존하기 때문에 단위테스트지만 외부에 영향을 받는 게 맞는 것인가? 하는 생각이 들었습니다.

1단계에서 제시한 그림은 delete에서 DeleteHistories까지 처리하는 그림을 제시했는데, deleteHistories라는 메서드를 만들어서 delete=true하는 동작과 deleteHistories를 save하기 위해 원하는 List를 만드는 deleteHistories 메서드를 분리하는 것도 적절하지 않나? 라는 생각을 했습니다. 이 편이 메서드를 더 잘게 쪼개는 것 같기도 하고, deleteHistory에 대한 요구조건이 바뀌었을 때 더 쉽게 짐작할 수 있을 것이라는 생각이 들었습니다.