### PR TITLE
1단계 - 레거시 코드 리팩터링

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
-# 학습 관리 시스템(Learning Management System)
-## 진행 방법
-* 학습 관리 시스템의 수강신청 요구사항을 파악한다.
-* 요구사항에 대한 구현을 완료한 후 자신의 github 아이디에 해당하는 브랜치에 Pull Request(이하 PR)를 통해 코드 리뷰 요청을 한다.
-* 코드 리뷰 피드백에 대한 개선 작업을 하고 다시 PUSH한다.
-* 모든 피드백을 완료하면 다음 단계를 도전하고 앞의 과정을 반복한다.
+## 학습 관리 시스템(Learning Management System)
 
-## 온라인 코드 리뷰 과정
-* [텍스트와 이미지로 살펴보는 온라인 코드 리뷰 과정](https://github.com/next-step/nextstep-docs/tree/master/codereview)
+### 질문 삭제하기 요구사항
+- 질문 데이터를 완전히 삭제하는 것이 아니라 데이터의 상태를 삭제 상태(deleted - boolean type)로 변경한다.
+- 로그인 사용자와 질문한 사람이 같은 경우 삭제 가능하다.
+- 답변이 없는 경우 삭제가 가능하다.
+- 질문자와 답변글의 모든답변자가 같은경우 삭제가가능하다.
+- 질문을 삭제할 때 답변 또한 삭제해야 하며, 답변의 삭제 또한 삭제 상태(deleted)를 변경
+한다.
+- 질문자와 답변자가 다른경우 답변을 삭제할 수 없다.
+- 질문과 답변 삭제 이력에 대한 정보를 DeleteHistory를 활용해 남긴다.
+
+### 리팩터링 요구사항
+- nextstep.qna.service.QnaService의 deleteQuestion()는 앞의 질문 삭제 기능을 구현한 코드이다. 이 메소드는 단위 테스트하기 어려운 코드와 단위 테스트 가능한 코드가 섞여 있다.
+- QnaService의 deleteQuestion() 메서드에 단위 테스트 가능한 코드(핵심 비지니스 로직)를 도메인 모델 객체에 구현한다.
+- QnaService의 비지니스 로직을 도메인 모델로 이동하는 리팩터링을 진행할 때 TDD로 구현한다.
+- QnaService의 deleteQuestion() 메서드에 대한 단위 테스트는 src/test/java 폴더 nextstep.qna.service.QnaServiceTest이다. 도메인 모델로 로직을 이동한 후에도 QnaServiceTest의 모든 테스트는 통과해야 한다.

--- a/src/main/java/nextstep/qna/CannotDeleteException.java
+++ b/src/main/java/nextstep/qna/CannotDeleteException.java
@@ -1,6 +1,6 @@
 package nextstep.qna;
 
-public class CannotDeleteException extends Exception {
+public class CannotDeleteException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public CannotDeleteException(String message) {

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -42,12 +42,12 @@ public class Answer {
         this.contents = contents;
     }
 
-    public DeleteHistory toDeleteHistory() {
+    public DeleteHistory toDeleteHistory(LocalDateTime time) {
         return new DeleteHistory(
                 ContentType.ANSWER,
                 this.id,
                 this.writer,
-                LocalDateTime.now()
+                time
         );
     }
 

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -42,6 +42,15 @@ public class Answer {
         this.contents = contents;
     }
 
+    public DeleteHistory toDeleteHistory() {
+        return new DeleteHistory(
+                ContentType.ANSWER,
+                this.id,
+                this.writer,
+                LocalDateTime.now()
+        );
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -18,9 +18,7 @@ public class Answer {
 
     private boolean deleted = false;
 
-    private LocalDateTime createdDate = LocalDateTime.now();
-
-    private LocalDateTime updatedDate;
+    private TimeStamped timeStamped;
 
     public Answer() {
     }

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -1,5 +1,6 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.qna.NotFoundException;
 import nextstep.qna.UnAuthorizedException;
 import nextstep.users.domain.NsUser;
@@ -47,7 +48,10 @@ public class Answer {
         return id;
     }
 
-    public Answer setDeleted(boolean deleted) {
+    public Answer setDeleted(NsUser loginUser, boolean deleted) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
         this.deleted = deleted;
         return this;
     }

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -48,12 +48,8 @@ public class Answer {
         return id;
     }
 
-    public Answer setDeleted(NsUser loginUser, boolean deleted) throws CannotDeleteException {
-        if (!isOwner(loginUser)) {
-            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-        }
-        this.deleted = deleted;
-        return this;
+    private void setDeleted() {
+        this.deleted = true;
     }
 
     public boolean isDeleted() {
@@ -74,6 +70,23 @@ public class Answer {
 
     public void toQuestion(Question question) {
         this.question = question;
+    }
+
+    public Answer delete(NsUser loginUser) {
+        validate(loginUser);
+
+        this.setDeleted();
+        return this;
+    }
+
+    private void validate(NsUser loginUser) {
+        checkLoginUserIsWriter(loginUser);
+    }
+
+    private void checkLoginUserIsWriter(NsUser loginUser) {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
     }
 
     @Override

--- a/src/main/java/nextstep/qna/domain/AnswerRepository.java
+++ b/src/main/java/nextstep/qna/domain/AnswerRepository.java
@@ -4,4 +4,6 @@ import java.util.List;
 
 public interface AnswerRepository {
     List<Answer> findByQuestion(Long questionId);
+
+    void update(Long answerId, Answer answer);
 }

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -2,6 +2,7 @@ package nextstep.qna.domain;
 
 import nextstep.users.domain.NsUser;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -30,10 +31,10 @@ public class Answers implements Iterable<Answer> {
         this.answers.add(answer);
     }
 
-    public List<DeleteHistory> toDeleteHistories() {
+    public List<DeleteHistory> toDeleteHistories(LocalDateTime time) {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         for (Answer answer : answers) {
-            deleteHistories.add(answer.toDeleteHistory());
+            deleteHistories.add(answer.toDeleteHistory(time));
         }
         return deleteHistories;
     }

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -31,8 +31,8 @@ public class Answers implements Iterable<Answer> {
         this.answers.add(answer);
     }
 
-    public List<DeleteHistory> toDeleteHistories(LocalDateTime time) {
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
+    public DeleteHistories toDeleteHistories(LocalDateTime time) {
+        DeleteHistories deleteHistories = new DeleteHistories();
         for (Answer answer : answers) {
             deleteHistories.add(answer.toDeleteHistory(time));
         }

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -30,6 +30,14 @@ public class Answers implements Iterable<Answer> {
         this.answers.add(answer);
     }
 
+    public List<DeleteHistory> toDeleteHistories() {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        for (Answer answer : answers) {
+            deleteHistories.add(answer.toDeleteHistory());
+        }
+        return deleteHistories;
+    }
+
     @Override
     public Iterator<Answer> iterator() {
         return this.answers.iterator();

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -1,0 +1,37 @@
+package nextstep.qna.domain;
+
+import nextstep.users.domain.NsUser;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class Answers implements Iterable<Answer> {
+    private final List<Answer> answers;
+
+    public Answers() {
+        this(new ArrayList<>());
+    }
+
+    public Answers(List<Answer> answers) {
+        this.answers = answers;
+    }
+
+    public Answers delete(NsUser loginUser) {
+        List<Answer> deletedAnswers = new ArrayList<>();
+        for (Answer answer : answers) {
+            deletedAnswers.add(answer.delete(loginUser));
+        }
+
+        return new Answers(deletedAnswers);
+    }
+
+    public void add(Answer answer) {
+        this.answers.add(answer);
+    }
+
+    @Override
+    public Iterator<Answer> iterator() {
+        return this.answers.iterator();
+    }
+}

--- a/src/main/java/nextstep/qna/domain/DeleteHistories.java
+++ b/src/main/java/nextstep/qna/domain/DeleteHistories.java
@@ -1,0 +1,46 @@
+package nextstep.qna.domain;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+public class DeleteHistories implements Iterable<DeleteHistory> {
+    private final List<DeleteHistory> deleteHistories;
+
+    public DeleteHistories() {
+        this(new ArrayList<>());
+    }
+
+    public DeleteHistories(List<DeleteHistory> deleteHistories) {
+        this.deleteHistories = deleteHistories;
+    }
+
+    public void add(DeleteHistories inputDeleteHistories) {
+        for(DeleteHistory deleteHistory : inputDeleteHistories) {
+            this.add(deleteHistory);
+        };
+    }
+
+    public void add(DeleteHistory deleteHistory) {
+        this.deleteHistories.add(deleteHistory);
+    }
+
+    @Override
+    public Iterator<DeleteHistory> iterator() {
+        return this.deleteHistories.iterator();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DeleteHistories that = (DeleteHistories) o;
+        return Objects.equals(deleteHistories, that.deleteHistories);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(deleteHistories);
+    }
+}

--- a/src/main/java/nextstep/qna/domain/DeleteHistory.java
+++ b/src/main/java/nextstep/qna/domain/DeleteHistory.java
@@ -37,7 +37,7 @@ public class DeleteHistory {
         );
     }
 
-    public static List<DeleteHistory> from(List<Answer> answers) {
+    public static List<DeleteHistory> from(Answers answers) {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
 
         for (Answer answer : answers) {

--- a/src/main/java/nextstep/qna/domain/DeleteHistory.java
+++ b/src/main/java/nextstep/qna/domain/DeleteHistory.java
@@ -26,6 +26,24 @@ public class DeleteHistory {
         this.createdDate = createdDate;
     }
 
+    public static DeleteHistory from(Question question) {
+        return new DeleteHistory(
+                ContentType.QUESTION,
+                question.getId(),
+                question.getWriter(),
+                LocalDateTime.now()
+        );
+    }
+
+    public static DeleteHistory from(Answer answer) {
+        return new DeleteHistory(
+                ContentType.QUESTION,
+                answer.getId(),
+                answer.getWriter(),
+                LocalDateTime.now()
+        );
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/nextstep/qna/domain/DeleteHistory.java
+++ b/src/main/java/nextstep/qna/domain/DeleteHistory.java
@@ -28,34 +28,6 @@ public class DeleteHistory {
         this.createdDate = createdDate;
     }
 
-    public static DeleteHistory from(Question question) {
-        return new DeleteHistory(
-                ContentType.QUESTION,
-                question.getId(),
-                question.getWriter(),
-                LocalDateTime.now()
-        );
-    }
-
-    public static List<DeleteHistory> from(Answers answers) {
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-
-        for (Answer answer : answers) {
-            deleteHistories.add(from(answer));
-        }
-
-        return deleteHistories;
-    }
-
-    public static DeleteHistory from(Answer answer) {
-        return new DeleteHistory(
-                ContentType.ANSWER,
-                answer.getId(),
-                answer.getWriter(),
-                LocalDateTime.now()
-        );
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/nextstep/qna/domain/DeleteHistory.java
+++ b/src/main/java/nextstep/qna/domain/DeleteHistory.java
@@ -3,6 +3,8 @@ package nextstep.qna.domain;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class DeleteHistory {
@@ -35,9 +37,19 @@ public class DeleteHistory {
         );
     }
 
+    public static List<DeleteHistory> from(List<Answer> answers) {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+
+        for (Answer answer : answers) {
+            deleteHistories.add(from(answer));
+        }
+
+        return deleteHistories;
+    }
+
     public static DeleteHistory from(Answer answer) {
         return new DeleteHistory(
-                ContentType.QUESTION,
+                ContentType.ANSWER,
                 answer.getId(),
                 answer.getWriter(),
                 LocalDateTime.now()

--- a/src/main/java/nextstep/qna/domain/DeleteHistoryRepository.java
+++ b/src/main/java/nextstep/qna/domain/DeleteHistoryRepository.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public interface DeleteHistoryRepository {
 
-    void saveAll(List<DeleteHistory> deleteHistories);
+    void saveAll(DeleteHistories deleteHistories);
 }

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -20,9 +20,7 @@ public class Question {
 
     private boolean deleted = false;
 
-    private LocalDateTime createdDate = LocalDateTime.now();
-
-    private LocalDateTime updatedDate;
+    private TimeStamped timeStamped;
 
     public Question() {
     }

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -106,12 +106,12 @@ public class Question {
         }
     }
 
-    public List<DeleteHistory> toDeleteHistories(NsUser loginUser, LocalDateTime date) {
+    public DeleteHistories toDeleteHistories(NsUser loginUser, LocalDateTime date) {
         validate(loginUser);
 
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        DeleteHistories deleteHistories = new DeleteHistories();
         deleteHistories.add(toDeleteHistory(date));
-        deleteHistories.addAll(answers.toDeleteHistories(date));
+        deleteHistories.add(answers.toDeleteHistories(date));
         return deleteHistories;
     }
 

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -1,5 +1,6 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;
@@ -68,6 +69,10 @@ public class Question {
         answers.add(answer);
     }
 
+    public void setAnswers(List<Answer> answers) {
+        this.answers = answers;
+    }
+
     public boolean isOwner(NsUser loginUser) {
         return writer.equals(loginUser);
     }
@@ -88,5 +93,22 @@ public class Question {
     @Override
     public String toString() {
         return "Question [id=" + getId() + ", title=" + title + ", contents=" + contents + ", writer=" + writer + "]";
+    }
+
+    public Question delete(NsUser loginUser) throws CannotDeleteException {
+        this.setDeleted(true);
+
+        List<Answer> deletedAnswers = new ArrayList<>();
+        for (Answer answer : this.answers) {
+            if (!answer.isOwner(loginUser)) {
+                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+            }
+
+            answer.setDeleted(true);
+            deletedAnswers.add(answer);
+        }
+
+        this.setAnswers(deletedAnswers);
+        return this;
     }
 }

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -92,7 +92,7 @@ public class Question {
         validate(loginUser);
 
         this.setDeleted();
-        Answers deletedAnswers = answers.delete(loginUser);
+        this.answers = answers.delete(loginUser);
         return this;
     }
 
@@ -104,5 +104,21 @@ public class Question {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
+    }
+
+    public List<DeleteHistory> toDeleteHistories() {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        deleteHistories.add(toDeleteHistory());
+        deleteHistories.addAll(answers.toDeleteHistories());
+        return deleteHistories;
+    }
+
+    private DeleteHistory toDeleteHistory() {
+        return new DeleteHistory(
+                ContentType.QUESTION,
+                this.id,
+                this.writer,
+                LocalDateTime.now()
+        );
     }
 }

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -69,10 +69,6 @@ public class Question {
         answers.add(answer);
     }
 
-    public void setAnswers(List<Answer> answers) {
-        this.answers = answers;
-    }
-
     public boolean isOwner(NsUser loginUser) {
         return writer.equals(loginUser);
     }
@@ -98,17 +94,11 @@ public class Question {
     public Question delete(NsUser loginUser) throws CannotDeleteException {
         this.setDeleted(true);
 
-        List<Answer> deletedAnswers = new ArrayList<>();
         for (Answer answer : this.answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-
-            answer.setDeleted(true);
-            deletedAnswers.add(answer);
+            Answer deletedAnswer = answer.setDeleted(loginUser, true);
+            this.addAnswer(deletedAnswer);
         }
 
-        this.setAnswers(deletedAnswers);
         return this;
     }
 }

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -106,19 +106,21 @@ public class Question {
         }
     }
 
-    public List<DeleteHistory> toDeleteHistories() {
+    public List<DeleteHistory> toDeleteHistories(NsUser loginUser, LocalDateTime date) {
+        validate(loginUser);
+
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteHistories.add(toDeleteHistory());
-        deleteHistories.addAll(answers.toDeleteHistories());
+        deleteHistories.add(toDeleteHistory(date));
+        deleteHistories.addAll(answers.toDeleteHistories(date));
         return deleteHistories;
     }
 
-    private DeleteHistory toDeleteHistory() {
+    private DeleteHistory toDeleteHistory(LocalDateTime date) {
         return new DeleteHistory(
                 ContentType.QUESTION,
                 this.id,
                 this.writer,
-                LocalDateTime.now()
+                date
         );
     }
 }

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -73,9 +73,8 @@ public class Question {
         return writer.equals(loginUser);
     }
 
-    public Question setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
+    private void setDeleted() {
+        this.deleted = true;
     }
 
     public boolean isDeleted() {
@@ -91,14 +90,20 @@ public class Question {
         return "Question [id=" + getId() + ", title=" + title + ", contents=" + contents + ", writer=" + writer + "]";
     }
 
-    public Question delete(NsUser loginUser) throws CannotDeleteException {
-        this.setDeleted(true);
+    public Question delete(NsUser loginUser) {
+        validate(loginUser);
 
-        for (Answer answer : this.answers) {
-            Answer deletedAnswer = answer.setDeleted(loginUser, true);
-            this.addAnswer(deletedAnswer);
-        }
-
+        this.setDeleted();
         return this;
+    }
+
+    private void validate(NsUser loginUser) {
+        checkLoginUserIsWriter(loginUser);
+    }
+
+    private void checkLoginUserIsWriter(NsUser loginUser) {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
     }
 }

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -92,6 +92,7 @@ public class Question {
         validate(loginUser);
 
         this.setDeleted();
+        Answers deletedAnswers = answers.delete(loginUser);
         return this;
     }
 

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -16,7 +16,7 @@ public class Question {
 
     private NsUser writer;
 
-    private List<Answer> answers = new ArrayList<>();
+    private Answers answers = new Answers();
 
     private boolean deleted = false;
 
@@ -79,7 +79,7 @@ public class Question {
         return deleted;
     }
 
-    public List<Answer> getAnswers() {
+    public Answers getAnswers() {
         return answers;
     }
 

--- a/src/main/java/nextstep/qna/domain/QuestionRepository.java
+++ b/src/main/java/nextstep/qna/domain/QuestionRepository.java
@@ -4,4 +4,6 @@ import java.util.Optional;
 
 public interface QuestionRepository {
     Optional<Question> findById(Long id);
+
+    void update(Long questionId, Question question);
 }

--- a/src/main/java/nextstep/qna/domain/TimeStamped.java
+++ b/src/main/java/nextstep/qna/domain/TimeStamped.java
@@ -1,0 +1,25 @@
+package nextstep.qna.domain;
+
+import java.time.LocalDateTime;
+
+public class TimeStamped {
+    private LocalDateTime createdDate = LocalDateTime.now();
+
+    private LocalDateTime updatedDate;
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(LocalDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public LocalDateTime getUpdatedDate() {
+        return updatedDate;
+    }
+
+    public void setUpdatedDate(LocalDateTime updatedDate) {
+        this.updatedDate = updatedDate;
+    }
+}

--- a/src/main/java/nextstep/qna/infrastructure/JdbcAnswerRepository.java
+++ b/src/main/java/nextstep/qna/infrastructure/JdbcAnswerRepository.java
@@ -12,4 +12,9 @@ public class JdbcAnswerRepository implements AnswerRepository {
     public List<Answer> findByQuestion(Long questionId) {
         return null;
     }
+
+    @Override
+    public void update(Long answerId, Answer answer) {
+
+    }
 }

--- a/src/main/java/nextstep/qna/infrastructure/JdbcDeleteHistoryRepository.java
+++ b/src/main/java/nextstep/qna/infrastructure/JdbcDeleteHistoryRepository.java
@@ -1,5 +1,6 @@
 package nextstep.qna.infrastructure;
 
+import nextstep.qna.domain.DeleteHistories;
 import nextstep.qna.domain.DeleteHistory;
 import nextstep.qna.domain.DeleteHistoryRepository;
 import org.springframework.stereotype.Repository;
@@ -9,7 +10,7 @@ import java.util.List;
 @Repository("deleteHistoryRepository")
 public class JdbcDeleteHistoryRepository implements DeleteHistoryRepository {
     @Override
-    public void saveAll(List<DeleteHistory> deleteHistories) {
+    public void saveAll(DeleteHistories deleteHistories) {
 
     }
 }

--- a/src/main/java/nextstep/qna/infrastructure/JdbcQuestionRepository.java
+++ b/src/main/java/nextstep/qna/infrastructure/JdbcQuestionRepository.java
@@ -12,4 +12,9 @@ public class JdbcQuestionRepository implements QuestionRepository {
     public Optional<Question> findById(Long id) {
         return Optional.empty();
     }
+
+    @Override
+    public void update(Long questionId, Question question) {
+
+    }
 }

--- a/src/main/java/nextstep/qna/service/DeleteHistoryService.java
+++ b/src/main/java/nextstep/qna/service/DeleteHistoryService.java
@@ -1,5 +1,6 @@
 package nextstep.qna.service;
 
+import nextstep.qna.domain.DeleteHistories;
 import nextstep.qna.domain.DeleteHistory;
 import nextstep.qna.domain.DeleteHistoryRepository;
 import org.springframework.stereotype.Service;
@@ -15,7 +16,7 @@ public class DeleteHistoryService {
     private DeleteHistoryRepository deleteHistoryRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void saveAll(List<DeleteHistory> deleteHistories) {
+    public void saveAll(DeleteHistories deleteHistories) {
         deleteHistoryRepository.saveAll(deleteHistories);
     }
 }

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -2,13 +2,16 @@ package nextstep.qna.service;
 
 import nextstep.qna.CannotDeleteException;
 import nextstep.qna.NotFoundException;
-import nextstep.qna.domain.*;
+import nextstep.qna.domain.AnswerRepository;
+import nextstep.qna.domain.DeleteHistory;
+import nextstep.qna.domain.Question;
+import nextstep.qna.domain.QuestionRepository;
 import nextstep.users.domain.NsUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Resource;
-import java.util.ArrayList;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service("qnaService")
@@ -23,12 +26,12 @@ public class QnAService {
     private DeleteHistoryService deleteHistoryService;
 
     @Transactional
-    public void deleteQuestion(NsUser loginUser, long questionId) {
+    public void deleteQuestion(NsUser loginUser, long questionId, LocalDateTime date) {
         Question question = getQuestion(questionId);
         question = question.delete(loginUser);
         questionRepository.update(questionId, question);
 
-        List<DeleteHistory> deleteHistories = question.toDeleteHistories();
+        List<DeleteHistory> deleteHistories = question.toDeleteHistories(loginUser, date);
         deleteHistoryService.saveAll(deleteHistories);
     }
 

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -30,18 +30,11 @@ public class QnAService {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
 
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
+        question = question.delete(loginUser);
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
+        for (Answer answer : question.getAnswers()) {
             deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -2,10 +2,7 @@ package nextstep.qna.service;
 
 import nextstep.qna.CannotDeleteException;
 import nextstep.qna.NotFoundException;
-import nextstep.qna.domain.AnswerRepository;
-import nextstep.qna.domain.DeleteHistory;
-import nextstep.qna.domain.Question;
-import nextstep.qna.domain.QuestionRepository;
+import nextstep.qna.domain.*;
 import nextstep.users.domain.NsUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,7 +28,7 @@ public class QnAService {
         question = question.delete(loginUser);
         questionRepository.update(questionId, question);
 
-        List<DeleteHistory> deleteHistories = question.toDeleteHistories(loginUser, date);
+        DeleteHistories deleteHistories = question.toDeleteHistories(loginUser, date);
         deleteHistoryService.saveAll(deleteHistories);
     }
 

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -24,36 +24,15 @@ public class QnAService {
 
     @Transactional
     public void deleteQuestion(NsUser loginUser, long questionId) {
-        Question question = questionToBeDeleted(loginUser, questionId);
-        questionRepository.update(questionId, question);
-
-        Answers answers = answersToBeDeleted(loginUser, questionId);
-        for (Answer answer : answers) {
-            answerRepository.update(answer.getId(), answer);
-        }
-
-        List<DeleteHistory> deleteHistories = deleteHistoriesOf(question, answers);
-        deleteHistoryService.saveAll(deleteHistories);
-    }
-
-    private Question questionToBeDeleted(NsUser loginUser, long questionId) {
         Question question = getQuestion(questionId);
-        question = question.delete(loginUser);
-        return question;
+        question.delete(loginUser);
+
+        List<DeleteHistory> deleteHistories = deleteHistoriesOf(question, question.getAnswers());
+        deleteHistoryService.saveAll(deleteHistories);
     }
 
     private Question getQuestion(long questionId) throws CannotDeleteException {
         return questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
-    }
-
-    private Answers answersToBeDeleted(NsUser loginUser, long questionId) {
-        Answers answers = new Answers(getAnswers(questionId));
-        Answers deletedAnswers = answers.delete(loginUser);
-        return deletedAnswers;
-    }
-
-    private List<Answer> getAnswers(long questionId) {
-        return answerRepository.findByQuestion(questionId);
     }
 
     private List<DeleteHistory> deleteHistoriesOf(Question question, Answers answers) {

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -27,7 +27,7 @@ public class QnAService {
         Question question = questionToBeDeleted(loginUser, questionId);
         questionRepository.update(questionId, question);
 
-        List<Answer> answers = answersToBeDeleted(loginUser, questionId);
+        Answers answers = answersToBeDeleted(loginUser, questionId);
         for (Answer answer : answers) {
             answerRepository.update(answer.getId(), answer);
         }
@@ -46,13 +46,9 @@ public class QnAService {
         return questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
     }
 
-    private List<Answer> answersToBeDeleted(NsUser loginUser, long questionId) {
-        List<Answer> deletedAnswers = new ArrayList<>();
-        for (Answer answer : getAnswers(questionId)) {
-            answer = answer.delete(loginUser);
-            deletedAnswers.add(answer);
-        }
-
+    private Answers answersToBeDeleted(NsUser loginUser, long questionId) {
+        Answers answers = new Answers(getAnswers(questionId));
+        Answers deletedAnswers = answers.delete(loginUser);
         return deletedAnswers;
     }
 
@@ -60,7 +56,7 @@ public class QnAService {
         return answerRepository.findByQuestion(questionId);
     }
 
-    private List<DeleteHistory> deleteHistoriesOf(Question question, List<Answer> answers) {
+    private List<DeleteHistory> deleteHistoriesOf(Question question, Answers answers) {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         deleteHistories.add(DeleteHistory.from(question));
         deleteHistories.addAll(DeleteHistory.from(answers));

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -52,15 +52,13 @@ public class QnAService {
     }
 
     private DeleteHistory deleteHistoryFromQuestion(Question question) {
-        return new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now());
+        return DeleteHistory.from(question);
     }
 
     private List<DeleteHistory> deleteHistoryFromAnswers(List<Answer> answers) {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         for (Answer answer : answers) {
-            DeleteHistory deletedAnswerHistory =
-                    new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now());
-            deleteHistories.add(deletedAnswerHistory);
+            deleteHistories.add(DeleteHistory.from(answer));
         }
 
         return deleteHistories;

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -25,20 +25,14 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(NsUser loginUser, long questionId) {
         Question question = getQuestion(questionId);
-        question.delete(loginUser);
+        question = question.delete(loginUser);
+        questionRepository.update(questionId, question);
 
-        List<DeleteHistory> deleteHistories = deleteHistoriesOf(question, question.getAnswers());
+        List<DeleteHistory> deleteHistories = question.toDeleteHistories();
         deleteHistoryService.saveAll(deleteHistories);
     }
 
     private Question getQuestion(long questionId) throws CannotDeleteException {
         return questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
-    }
-
-    private List<DeleteHistory> deleteHistoriesOf(Question question, Answers answers) {
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteHistories.add(DeleteHistory.from(question));
-        deleteHistories.addAll(DeleteHistory.from(answers));
-        return deleteHistories;
     }
 }

--- a/src/test/java/nextstep/qna/domain/AnswerTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswerTest.java
@@ -1,10 +1,32 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUserTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AnswerTest {
     public static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
     public static final Answer A3 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q2, "Answers Contents3");
     public static final Answer A4 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q2, "Answers Contents4");
+
+    @Test
+    @DisplayName("질문 작성자와 답변 작성자가 같으면 답변을 삭제 상태로 변경한다")
+    void setDeleted_success() throws CannotDeleteException {
+        Answer deletedAnswer = A1.setDeleted(NsUserTest.JAVAJIGI, true);
+
+        assertThat(deletedAnswer.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("질문 작성자와 답변 작성자가 다르면 삭제할 수 없다는 예외를 던진다")
+    void setDeleted_different_questionWriter_AnswerWriter_throwsException() {
+        assertThatThrownBy(
+                () -> A1.setDeleted(NsUserTest.SANJIGI, true)
+        ).isInstanceOf(CannotDeleteException.class);
+    }
 }

--- a/src/test/java/nextstep/qna/domain/AnswerTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswerTest.java
@@ -9,24 +9,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AnswerTest {
-    public static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
-    public static final Answer A2 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
-    public static final Answer A3 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q2, "Answers Contents3");
-    public static final Answer A4 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q2, "Answers Contents4");
+    private static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
+    private static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, Q1, "Answers Contents1");
+    private static final Answer A2 = new Answer(NsUserTest.SANJIGI, Q1, "Answers Contents2");
 
     @Test
-    @DisplayName("질문 작성자와 답변 작성자가 같으면 답변을 삭제 상태로 변경한다")
+    @DisplayName("답변 작성자가 로그인한 사용자면 답변을 삭제 상태로 변경하고 해당 답변을 반환한다")
     void setDeleted_success() throws CannotDeleteException {
-        Answer deletedAnswer = A1.setDeleted(NsUserTest.JAVAJIGI, true);
+        Answer deletedAnswer = A1.delete(NsUserTest.JAVAJIGI);
 
         assertThat(deletedAnswer.isDeleted()).isTrue();
     }
 
     @Test
-    @DisplayName("질문 작성자와 답변 작성자가 다르면 삭제할 수 없다는 예외를 던진다")
-    void setDeleted_different_questionWriter_AnswerWriter_throwsException() {
+    @DisplayName("질문 작성자가 로그인한 사용자가 아니면 삭제할 수 없다는 예외를 던진다")
+    void setDeleted_different_answerWriter_loginUser_throwsException() {
         assertThatThrownBy(
-                () -> A1.setDeleted(NsUserTest.SANJIGI, true)
+                () -> A2.delete(NsUserTest.JAVAJIGI)
         ).isInstanceOf(CannotDeleteException.class);
     }
 }

--- a/src/test/java/nextstep/qna/domain/AnswerTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswerTest.java
@@ -5,4 +5,6 @@ import nextstep.users.domain.NsUserTest;
 public class AnswerTest {
     public static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+    public static final Answer A3 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q2, "Answers Contents3");
+    public static final Answer A4 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q2, "Answers Contents4");
 }

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -6,39 +6,29 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static nextstep.qna.domain.AnswerTest.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class QuestionTest {
-    public static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
-    public static final Question Q2 = new Question(NsUserTest.SANJIGI, "title2", "contents2");
-
-    @BeforeEach
-    void setUp() {
-        Q1.addAnswer(A1);
-        Q1.addAnswer(A2);
-
-        Q2.addAnswer(A3);
-        Q2.addAnswer(A4);
-    }
+    private static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
+    private static final Question Q2 = new Question(NsUserTest.SANJIGI, "title2", "contents2");
 
     @Test
-    @DisplayName("질문 작성자와 답변 작성자가 같으면 데이터를 삭제 상태로 변경한다")
+    @DisplayName("질문 작성자가 로그인한 사용자면 질문을 삭제 상태로 변경하고 해당 질문을 반환한다")
     void delete_success() throws CannotDeleteException {
-        Question question = Q2.delete(NsUserTest.SANJIGI);
+        Question deletedQuestion = Q1.delete(NsUserTest.JAVAJIGI);
 
-        assertThat(question.isDeleted()).isTrue();
-        for (Answer answer : question.getAnswers()) {
-            assertThat(answer.isDeleted()).isTrue();
-        }
+        assertThat(deletedQuestion.isDeleted()).isTrue();
     }
 
     @Test
-    @DisplayName("질문 작성자와 답변 작성자가 다르면 삭제할 수 없다는 예외를 던진다")
-    void delete_different_questionWriter_AnswerWriter_throwsException() {
+    @DisplayName("질문 작성자가 로그인한 사용자가 아니면 삭제할 수 없다는 예외를 던진다")
+    void delete_different_questionWriter_loginUser_throwsException() {
         assertThatThrownBy(
-                () -> Q1.delete(NsUserTest.JAVAJIGI)
+                () -> Q2.delete(NsUserTest.JAVAJIGI)
         ).isInstanceOf(CannotDeleteException.class);
     }
 }

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -14,14 +14,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class QuestionTest {
     private static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
+    private static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, Q1, "Answers Contents1");
+    private static final Answer A2 = new Answer(NsUserTest.SANJIGI, Q1, "Answers Contents2");
+
     private static final Question Q2 = new Question(NsUserTest.SANJIGI, "title2", "contents2");
 
     @Test
     @DisplayName("질문 작성자가 로그인한 사용자면 질문을 삭제 상태로 변경하고 해당 질문을 반환한다")
     void delete_success() throws CannotDeleteException {
         Question deletedQuestion = Q1.delete(NsUserTest.JAVAJIGI);
-
         assertThat(deletedQuestion.isDeleted()).isTrue();
+
+        Answers answers = deletedQuestion.getAnswers();
+        for (Answer answer : answers) {
+            assertThat(answer.isDeleted()).isTrue();
+        }
     }
 
     @Test

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -1,8 +1,44 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUserTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static nextstep.qna.domain.AnswerTest.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class QuestionTest {
     public static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
     public static final Question Q2 = new Question(NsUserTest.SANJIGI, "title2", "contents2");
+
+    @BeforeEach
+    void setUp() {
+        Q1.addAnswer(A1);
+        Q1.addAnswer(A2);
+
+        Q2.addAnswer(A3);
+        Q2.addAnswer(A4);
+    }
+
+    @Test
+    @DisplayName("질문 작성자와 답변 작성자가 같으면 데이터를 삭제 상태로 변경한다")
+    void delete_success() throws CannotDeleteException {
+        Question question = Q2.delete(NsUserTest.SANJIGI);
+
+        assertThat(question.isDeleted()).isTrue();
+        for (Answer answer : question.getAnswers()) {
+            assertThat(answer.isDeleted()).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("질문 작성자와 답변 작성자가 다르면 삭제할 수 없다는 예외를 던진다")
+    void delete_different_questionWriter_AnswerWriter_throwsException() {
+        assertThatThrownBy(
+                () -> Q1.delete(NsUserTest.JAVAJIGI)
+        ).isInstanceOf(CannotDeleteException.class);
+    }
 }

--- a/src/test/java/nextstep/qna/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/qna/service/QnaServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,6 +39,8 @@ public class QnaServiceTest {
     private Question question;
     private List<Answer> answers = new ArrayList<>();
     private Answer answer;
+    private LocalDateTime date = LocalDateTime.of(2023, 12, 4, 23, 0);
+
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -52,7 +55,7 @@ public class QnaServiceTest {
         when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
 
         assertThat(question.isDeleted()).isFalse();
-        qnAService.deleteQuestion(NsUserTest.JAVAJIGI, question.getId());
+        qnAService.deleteQuestion(NsUserTest.JAVAJIGI, question.getId(), date);
 
         assertThat(question.isDeleted()).isTrue();
         verifyDeleteHistories();
@@ -63,7 +66,7 @@ public class QnaServiceTest {
         when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
 
         assertThatThrownBy(() -> {
-            qnAService.deleteQuestion(NsUserTest.SANJIGI, question.getId());
+            qnAService.deleteQuestion(NsUserTest.SANJIGI, question.getId(), date);
         }).isInstanceOf(CannotDeleteException.class);
     }
 
@@ -71,7 +74,7 @@ public class QnaServiceTest {
     public void delete_성공_질문자_답변자_같음() throws Exception {
         when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
 
-        qnAService.deleteQuestion(NsUserTest.JAVAJIGI, question.getId());
+        qnAService.deleteQuestion(NsUserTest.JAVAJIGI, question.getId(), date);
 
         assertThat(question.isDeleted()).isTrue();
         assertThat(answer.isDeleted()).isTrue();
@@ -83,14 +86,14 @@ public class QnaServiceTest {
         when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
 
         assertThatThrownBy(() -> {
-            qnAService.deleteQuestion(NsUserTest.SANJIGI, question.getId());
+            qnAService.deleteQuestion(NsUserTest.SANJIGI, question.getId(), date);
         }).isInstanceOf(CannotDeleteException.class);
     }
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()));
-        deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), date));
+        deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), date));
 
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/nextstep/qna/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/qna/service/QnaServiceTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class QnaServiceTest {
-    private static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
-
     @Mock
     private QuestionRepository questionRepository;
 
@@ -44,7 +42,7 @@ public class QnaServiceTest {
     @BeforeEach
     public void setUp() throws Exception {
         question = new Question(1L, NsUserTest.JAVAJIGI, "title1", "contents1");
-        answer = new Answer(11L, NsUserTest.JAVAJIGI, Q1, "Answers Contents1");
+        answer = new Answer(11L, NsUserTest.JAVAJIGI, question, "Answers Contents1");
         answers.add(answer);
         question.addAnswer(answer);
     }

--- a/src/test/java/nextstep/qna/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/qna/service/QnaServiceTest.java
@@ -10,10 +10,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -91,7 +89,7 @@ public class QnaServiceTest {
     }
 
     private void verifyDeleteHistories() {
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        DeleteHistories deleteHistories = new DeleteHistories();
         deleteHistories.add(new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), date));
         deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), date));
 

--- a/src/test/java/nextstep/qna/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/qna/service/QnaServiceTest.java
@@ -71,7 +71,6 @@ public class QnaServiceTest {
     @Test
     public void delete_성공_질문자_답변자_같음() throws Exception {
         when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestion(question.getId())).thenReturn(answers);
 
         qnAService.deleteQuestion(NsUserTest.JAVAJIGI, question.getId());
 

--- a/src/test/java/nextstep/qna/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/qna/service/QnaServiceTest.java
@@ -50,7 +50,6 @@ public class QnaServiceTest {
     @Test
     public void delete_성공() throws Exception {
         when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
-        when(answerRepository.findByQuestion(question.getId())).thenReturn(answers);
 
         assertThat(question.isDeleted()).isFalse();
         qnAService.deleteQuestion(NsUserTest.JAVAJIGI, question.getId());


### PR DESCRIPTION
## 학습 관리 시스템(Learning Management System)

### 질문 삭제하기 요구사항
- 질문 데이터를 완전히 삭제하는 것이 아니라 데이터의 상태를 삭제 상태(deleted - boolean type)로 변경한다.
- 로그인 사용자와 질문한 사람이 같은 경우 삭제 가능하다.
- 답변이 없는 경우 삭제가 가능하다.
- 질문자와 답변글의 모든답변자가 같은경우 삭제가가능하다.
- 질문을 삭제할 때 답변 또한 삭제해야 하며, 답변의 삭제 또한 삭제 상태(deleted)를 변경
한다.
- 질문자와 답변자가 다른경우 답변을 삭제할 수 없다.
- 질문과 답변 삭제 이력에 대한 정보를 DeleteHistory를 활용해 남긴다.

### 리팩터링 요구사항
- nextstep.qna.service.QnaService의 deleteQuestion()는 앞의 질문 삭제 기능을 구현한 코드이다. 이 메소드는 단위 테스트하기 어려운 코드와 단위 테스트 가능한 코드가 섞여 있다.
- QnaService의 deleteQuestion() 메서드에 단위 테스트 가능한 코드(핵심 비지니스 로직)를 도메인 모델 객체에 구현한다.
- QnaService의 비지니스 로직을 도메인 모델로 이동하는 리팩터링을 진행할 때 TDD로 구현한다.
- QnaService의 deleteQuestion() 메서드에 대한 단위 테스트는 src/test/java 폴더 nextstep.qna.service.QnaServiceTest이다. 도메인 모델로 로직을 이동한 후에도 QnaServiceTest의 모든 테스트는 통과해야 한다.