### PR TITLE
Step1 - 레거시 코드 리팩토링

### DIFF
--- a/src/main/java/nextstep/qna/CannotDeleteException.java
+++ b/src/main/java/nextstep/qna/CannotDeleteException.java
@@ -1,6 +1,6 @@
 package nextstep.qna;
 
-public class CannotDeleteException extends Exception {
+public class CannotDeleteException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public CannotDeleteException(String message) {

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -74,7 +74,7 @@ public class Answer {
         }
 
         this.deleted = true;
-        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
+        return DeleteHistory.answerOf(id, writer, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -68,7 +68,7 @@ public class Answer {
         this.question = question;
     }
 
-    public DeleteHistory delete(NsUser loginUser) throws CannotDeleteException {
+    public DeleteHistory delete(NsUser loginUser) {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
         }

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -1,5 +1,6 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.qna.NotFoundException;
 import nextstep.qna.UnAuthorizedException;
 import nextstep.users.domain.NsUser;
@@ -47,11 +48,6 @@ public class Answer {
         return id;
     }
 
-    public Answer setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
-    }
-
     public boolean isDeleted() {
         return deleted;
     }
@@ -70,6 +66,15 @@ public class Answer {
 
     public void toQuestion(Question question) {
         this.question = question;
+    }
+
+    public DeleteHistory delete(NsUser loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+
+        this.deleted = true;
+        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
     }
 
     @Override

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -1,11 +1,10 @@
 package nextstep.qna.domain;
 
+import java.time.LocalDateTime;
 import nextstep.qna.CannotDeleteException;
 import nextstep.qna.NotFoundException;
 import nextstep.qna.UnAuthorizedException;
 import nextstep.users.domain.NsUser;
-
-import java.time.LocalDateTime;
 
 public class Answer {
     private Long id;

--- a/src/main/java/nextstep/qna/domain/DeleteHistory.java
+++ b/src/main/java/nextstep/qna/domain/DeleteHistory.java
@@ -26,6 +26,14 @@ public class DeleteHistory {
         this.createdDate = createdDate;
     }
 
+    public static DeleteHistory questionOf(Long contentId, NsUser deletedBy, LocalDateTime createdDate) {
+        return new DeleteHistory(ContentType.QUESTION, contentId, deletedBy, createdDate);
+    }
+
+    public static DeleteHistory answerOf(Long contentId, NsUser deletedBy, LocalDateTime createdDate) {
+        return new DeleteHistory(ContentType.ANSWER, contentId, deletedBy, createdDate);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -1,9 +1,11 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class Question {
@@ -72,17 +74,30 @@ public class Question {
         return writer.equals(loginUser);
     }
 
-    public Question setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
-    }
-
     public boolean isDeleted() {
         return deleted;
     }
 
-    public List<Answer> getAnswers() {
-        return answers;
+    public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+
+        List<DeleteHistory> deleteHistories = deleteHistories(loginUser);
+        this.deleted = true;
+
+        return deleteHistories;
+    }
+
+    private List<DeleteHistory> deleteHistories(NsUser loginUser) throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
+        for (Answer answer : answers) {
+            deleteHistories.add(answer.delete(loginUser));
+        }
+
+        return deleteHistories;
     }
 
     @Override

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -1,12 +1,10 @@
 package nextstep.qna.domain;
 
-import nextstep.qna.CannotDeleteException;
-import nextstep.users.domain.NsUser;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import nextstep.qna.CannotDeleteException;
+import nextstep.users.domain.NsUser;
 
 public class Question {
     private Long id;

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -92,11 +92,8 @@ public class Question {
     private List<DeleteHistory> deleteHistories(NsUser loginUser) throws CannotDeleteException {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
 
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
-        for (Answer answer : answers) {
-            deleteHistories.add(answer.delete(loginUser));
-        }
-
+        deleteHistories.add(DeleteHistory.questionOf(id, writer, LocalDateTime.now()));
+        answers.forEach(answer -> deleteHistories.add(answer.delete(loginUser)));
         return deleteHistories;
     }
 

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -78,7 +78,7 @@ public class Question {
         return deleted;
     }
 
-    public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
+    public List<DeleteHistory> delete(NsUser loginUser) {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
@@ -89,7 +89,7 @@ public class Question {
         return deleteHistories;
     }
 
-    private List<DeleteHistory> deleteHistories(NsUser loginUser) throws CannotDeleteException {
+    private List<DeleteHistory> deleteHistories(NsUser loginUser) {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
 
         deleteHistories.add(DeleteHistory.questionOf(id, writer, LocalDateTime.now()));

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -26,24 +26,6 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(NsUser loginUser, long questionId) throws CannotDeleteException {
         Question question = questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        deleteHistoryService.saveAll(question.delete(loginUser));
     }
 }

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -1,16 +1,13 @@
 package nextstep.qna.service;
 
-import nextstep.qna.CannotDeleteException;
+import javax.annotation.Resource;
 import nextstep.qna.NotFoundException;
-import nextstep.qna.domain.*;
+import nextstep.qna.domain.AnswerRepository;
+import nextstep.qna.domain.Question;
+import nextstep.qna.domain.QuestionRepository;
 import nextstep.users.domain.NsUser;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.annotation.Resource;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service("qnaService")
 public class QnAService {

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -24,7 +24,7 @@ public class QnAService {
     private DeleteHistoryService deleteHistoryService;
 
     @Transactional
-    public void deleteQuestion(NsUser loginUser, long questionId) throws CannotDeleteException {
+    public void deleteQuestion(NsUser loginUser, long questionId) {
         Question question = questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
         deleteHistoryService.saveAll(question.delete(loginUser));
     }

--- a/src/test/java/nextstep/qna/domain/AnswerTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswerTest.java
@@ -1,8 +1,30 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUserTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AnswerTest {
     public static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+    @Test
+    void delete() throws CannotDeleteException {
+        DeleteHistory deleteHistory = A1.delete(NsUserTest.JAVAJIGI);
+
+        assertThat(A1.isDeleted()).isTrue();
+        assertThat(deleteHistory).isEqualTo(
+                new DeleteHistory(ContentType.ANSWER, A1.getId(), NsUserTest.JAVAJIGI, LocalDateTime.now()));
+    }
+
+    @Test
+    void throw_exception_if_login_user_not_match() {
+        assertThatThrownBy(() -> A2.delete(NsUserTest.JAVAJIGI)).isInstanceOf(CannotDeleteException.class);
+    }
 }

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -1,8 +1,58 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
+import nextstep.users.domain.NsUser;
 import nextstep.users.domain.NsUserTest;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class QuestionTest {
     public static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
     public static final Question Q2 = new Question(NsUserTest.SANJIGI, "title2", "contents2");
+
+    @Test
+    void delete() throws CannotDeleteException {
+        List<DeleteHistory> deleteHistory = Q1.delete(NsUserTest.JAVAJIGI);
+
+        assertThat(Q1.isDeleted()).isTrue();
+        assertThat(deleteHistory).containsExactly(
+                new DeleteHistory(ContentType.QUESTION, Q1.getId(), Q1.getWriter(), LocalDateTime.now()));
+    }
+
+    @Test
+    void delete_question_with_answer() throws CannotDeleteException {
+        Question question = new Question(NsUserTest.JAVAJIGI, "title", "content");
+        Answer answer = new Answer(NsUserTest.JAVAJIGI, question, "content");
+        question.addAnswer(answer);
+        List<DeleteHistory> deleteHistories = question.delete(NsUserTest.JAVAJIGI);
+
+        assertThat(question.isDeleted()).isTrue();
+        assertThat(deleteHistories).containsExactlyInAnyOrder(
+                deleteHistory(ContentType.QUESTION, question.getId(), question.getWriter()),
+                deleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter()));
+    }
+
+    @Test
+    void throw_exception_if_delete_question_with_other_user_answer() throws CannotDeleteException {
+        Question question = new Question(NsUserTest.JAVAJIGI, "title", "content");
+        question.addAnswer(new Answer(NsUserTest.SANJIGI, question, "content"));
+
+        assertThatThrownBy(() -> question.delete(NsUserTest.JAVAJIGI))
+                .isInstanceOf(CannotDeleteException.class);
+    }
+
+    private DeleteHistory deleteHistory(ContentType contentType, Long contentId, NsUser writer) {
+        return new DeleteHistory(contentType, contentId, writer, LocalDateTime.now());
+    }
+
+    @Test
+    void throw_exception_if_login_user_not_match() {
+        assertThatThrownBy(() -> Q1.delete(NsUserTest.SANJIGI))
+                .isInstanceOf(CannotDeleteException.class);
+    }
 }


### PR DESCRIPTION
안녕하세요 리뷰어님 😀

수강신청 리팩토링 1단계 리뷰 요청 드립니다!

잘 부탁드립니다 🙇‍♂️

기존 코드 리팩토링 중 궁금한 점이 있어 리뷰 요청과 함께 문의드립니다.

* Question 클래스로 질문 삭제 로직을 위임하여 필드로 가진 Answer 클래스 리스트를 순회하면서 삭제 메세지를 보내도록 리팩토링하였습니다. 
* Question 클래스 delete 메소드에서 Answer 클래스를 순회하는 로직에서 스트림을 사용하려고 하니 Answer 클래스 delete 메소드에서 질문자와 댓글 작성자가 일치하지 않으면 CannotDelete Exception을 던지도록 되어 있고 해당 예외는 Exception을 상속 받았기 때문에 RuntimeExcetion 하위 클래스가 아니라 스트림 내에서는 로직 호출이 불가능하여 현재는 기존 foreach문으로 구현을 해둔 상태입니다.

* 그런데 만약 스트림 사용을 위해 Answer 클래스에서는 RuntimeException 하위 클래스를 던지도록 변경하고, Question 클래스 delete 메소드에서 예외를 잡아 CannotDelete Exception 으로 변경하여 외부로 던지도록 로직을 변경하고 싶은 유혹(?)이 생기는데 스트림을 위해서 체크 예외를 언체크 예외로 변경하는 것이 좋은 변경인지에 대한 확신이 들지 않아서 어떻게 생각하시는지 궁금합니다. 해당 애플리케이션 예외를 체크 예외로 만든건 호출하는 쪽에서 반드시 확인해야 한다는 의미인 것 같아서 변경하면 안될 것 같기도 해서요.