### PR TITLE
🚀 1단계 - 레거시 코드 리팩터링

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@
 
 ## 온라인 코드 리뷰 과정
 * [텍스트와 이미지로 살펴보는 온라인 코드 리뷰 과정](https://github.com/next-step/nextstep-docs/tree/master/codereview)
+
+## step 1 요구사항
+[X] QnaService의 비지니스 로직을 도메인 모델로 이동한다.
+[X] 도메인 모델로 로직을 이동한 후에도 QnaServiceTest의 모든 테스트는 통과해야 한다
+[X] 로그인 사용자 = 질문 작성자 = 답변 작성자 시 삭제한다.
+[X] 삭제 시 삭제 히스토리를 남긴다.
+[X] get을 사용하지 않는다.
+[X] 일급 콜렉션을 구현한다.

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -1,7 +1,7 @@
 package nextstep.qna.domain;
 
-import nextstep.qna.NotFoundException;
-import nextstep.qna.UnAuthorizedException;
+import nextstep.qna.exception.NotFoundException;
+import nextstep.qna.exception.UnAuthorizedException;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -5,8 +5,6 @@ import nextstep.qna.UnAuthorizedException;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 public class Answer {
     private Long id;
@@ -45,7 +43,7 @@ public class Answer {
 
         delete();
 
-        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
+        return new DeleteHistory(ContentType.ANSWER, id, writer);
     }
 
     private void delete() {

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -5,22 +5,17 @@ import nextstep.qna.UnAuthorizedException;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Answer {
     private Long id;
-
     private NsUser writer;
-
     private Question question;
-
     private String contents;
-
     private boolean deleted = false;
-
     private LocalDateTime createdDate = LocalDateTime.now();
-
     private LocalDateTime updatedDate;
-
     public Answer() {
     }
 
@@ -43,13 +38,18 @@ public class Answer {
         this.contents = contents;
     }
 
-    public Long getId() {
-        return id;
+    public DeleteHistory delete(NsUser loginUser) {
+        if (!isOwner(loginUser)) {
+            throw new UnAuthorizedException("답변을 삭제할 권한이 없습니다.");
+        }
+
+        delete();
+
+        return new DeleteHistory(ContentType.ANSWER, id, writer, LocalDateTime.now());
     }
 
-    public Answer setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
+    private void delete() {
+        this.deleted = true;
     }
 
     public boolean isDeleted() {
@@ -60,20 +60,12 @@ public class Answer {
         return this.writer.equals(writer);
     }
 
-    public NsUser getWriter() {
-        return writer;
-    }
-
-    public String getContents() {
-        return contents;
-    }
-
     public void toQuestion(Question question) {
         this.question = question;
     }
 
     @Override
     public String toString() {
-        return "Answer [id=" + getId() + ", writer=" + writer + ", contents=" + contents + "]";
+        return "Answer [id=" + id + ", writer=" + writer + ", contents=" + contents + "]";
     }
 }

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -14,40 +14,32 @@ public class Answer {
     private boolean deleted = false;
     private LocalDateTime createdDate = LocalDateTime.now();
     private LocalDateTime updatedDate;
-    public Answer() {
-    }
-
-    public Answer(NsUser writer, Question question, String contents) {
-        this(null, writer, question, contents);
-    }
 
     public Answer(Long id, NsUser writer, Question question, String contents) {
+        validate(writer, question);
         this.id = id;
-        if(writer == null) {
-            throw new UnAuthorizedException();
-        }
-
-        if(question == null) {
-            throw new NotFoundException();
-        }
-
         this.writer = writer;
         this.question = question;
         this.contents = contents;
     }
 
-    public DeleteHistory delete(NsUser loginUser) {
-        if (!isOwner(loginUser)) {
-            throw new UnAuthorizedException("답변을 삭제할 권한이 없습니다.");
+    private static void validate(NsUser writer, Question question) {
+        if(writer == null) {
+            throw new UnAuthorizedException();
         }
-
-        delete();
-
-        return new DeleteHistory(ContentType.ANSWER, id, writer);
+        if(question == null) {
+            throw new NotFoundException();
+        }
     }
 
-    private void delete() {
+    public DeleteHistory delete() {
         this.deleted = true;
+        this.updatedDate = LocalDateTime.now();
+        return createDeleteHistory();
+    }
+
+    public DeleteHistory createDeleteHistory() {
+        return new DeleteHistory(ContentType.ANSWER, id, writer);
     }
 
     public boolean isDeleted() {
@@ -66,4 +58,5 @@ public class Answer {
     public String toString() {
         return "Answer [id=" + id + ", writer=" + writer + ", contents=" + contents + "]";
     }
+
 }

--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -34,7 +34,6 @@ public class Answer {
 
     public DeleteHistory delete() {
         this.deleted = true;
-        this.updatedDate = LocalDateTime.now();
         return createDeleteHistory();
     }
 

--- a/src/main/java/nextstep/qna/domain/AnswerList.java
+++ b/src/main/java/nextstep/qna/domain/AnswerList.java
@@ -1,0 +1,2 @@
+package nextstep.qna.domain;public class AnswerList {
+}

--- a/src/main/java/nextstep/qna/domain/AnswerList.java
+++ b/src/main/java/nextstep/qna/domain/AnswerList.java
@@ -1,2 +1,0 @@
-package nextstep.qna.domain;public class AnswerList {
-}

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -28,6 +28,10 @@ public class Answers {
     return newList;
   }
 
+  public boolean isEmpty() {
+    return answerList.isEmpty();
+  }
+
   public boolean areAllAnswersSameWriter(NsUser loginUser) {
     return answerList.stream()
         .allMatch(answer -> answer.isOwner(loginUser));

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -1,0 +1,46 @@
+package nextstep.qna.domain;
+
+import nextstep.users.domain.NsUser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Answers {
+
+  private final List<Answer> answerList;
+
+  public Answers() {
+    this.answerList = Collections.emptyList();
+  }
+
+  public Answers(List<Answer> answers) {
+    this.answerList = Collections.unmodifiableList(new ArrayList<>(answers));
+  }
+
+  public Answers(Answers existingAnswers, Answer newAnswer) {
+    this(createNewList(existingAnswers.answerList, newAnswer));
+  }
+
+  private static List<Answer> createNewList(List<Answer> existingAnswers, Answer newAnswer) {
+    List<Answer> newList = new ArrayList<>(existingAnswers);
+    newList.add(newAnswer);
+    return newList;
+  }
+
+  public boolean areAllAnswersSameWriter(NsUser loginUser) {
+    return answerList.stream()
+        .allMatch(answer -> answer.isOwner(loginUser));
+  }
+
+  public List<DeleteHistory> delete() {
+    List<DeleteHistory> deleteHistoryList = new ArrayList<>();
+
+    for (Answer answer : answerList) {
+      DeleteHistory deleteHistory = answer.delete();
+      deleteHistoryList.add(deleteHistory);
+    }
+
+    return deleteHistoryList;
+  }
+}

--- a/src/main/java/nextstep/qna/domain/DeleteHistory.java
+++ b/src/main/java/nextstep/qna/domain/DeleteHistory.java
@@ -7,16 +7,16 @@ import java.util.Objects;
 
 public class DeleteHistory {
     private Long id;
-
     private ContentType contentType;
-
     private Long contentId;
-
     private NsUser deletedBy;
-
     private LocalDateTime createdDate = LocalDateTime.now();
 
     public DeleteHistory() {
+    }
+
+    public DeleteHistory(ContentType contentType, Long contentId, NsUser deletedBy) {
+        this(contentType, contentId, deletedBy, LocalDateTime.now());
     }
 
     public DeleteHistory(ContentType contentType, Long contentId, NsUser deletedBy, LocalDateTime createdDate) {

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -1,6 +1,6 @@
 package nextstep.qna.domain;
 
-import nextstep.qna.CannotDeleteException;
+import nextstep.qna.exception.CannotDeleteException;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -34,21 +34,25 @@ public class Question {
         return writer.equals(loginUser);
     }
 
-
     public boolean isDeleted() {
         return deleted;
     }
 
     public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
         validateDeletable(loginUser);
-        return this.delete();
+        return delete();
     }
 
     private void validateDeletable(NsUser loginUser) throws CannotDeleteException {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
         }
-        answers.areAllAnswersSameWriter(loginUser);
+        if (answers.isEmpty()) {
+            return;
+        }
+        if (!answers.areAllAnswersSameWriter(writer)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
     }
 
     private List<DeleteHistory> delete() {

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -46,7 +46,7 @@ public class Question {
         delete();
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer));
 
         deleteHistories.addAll(answers.stream()
                 .map(answer -> answer.delete(loginUser))

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -57,7 +57,10 @@ public class Question {
 
     private List<DeleteHistory> delete() {
         this.deleted = true;
+        return createDeleteHistoryList();
+    }
 
+    private List<DeleteHistory> createDeleteHistoryList() {
         List<DeleteHistory> deleteHistoryList = new ArrayList<>();
         deleteHistoryList.add(new DeleteHistory(ContentType.QUESTION, id, writer));
         deleteHistoryList.addAll(answers.delete());

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -57,7 +57,6 @@ public class Question {
 
     private List<DeleteHistory> delete() {
         this.deleted = true;
-        this.updatedDate = LocalDateTime.now();
 
         List<DeleteHistory> deleteHistoryList = new ArrayList<>();
         deleteHistoryList.add(new DeleteHistory(ContentType.QUESTION, id, writer));

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -1,26 +1,21 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Question {
     private Long id;
-
     private String title;
-
     private String contents;
-
     private NsUser writer;
-
     private List<Answer> answers = new ArrayList<>();
-
     private boolean deleted = false;
-
     private LocalDateTime createdDate = LocalDateTime.now();
-
     private LocalDateTime updatedDate;
 
     public Question() {
@@ -37,30 +32,40 @@ public class Question {
         this.contents = contents;
     }
 
-    public Long getId() {
-        return id;
+    public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
+        }
+
+        for (Answer answer : answers) {
+            if (!answer.isOwner(loginUser)) {
+                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+            }
+        }
+
+        delete();
+
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
+
+        deleteHistories.addAll(answers.stream()
+                .map(answer -> answer.delete(loginUser))
+                .collect(Collectors.toList()));
+
+        return deleteHistories;
     }
 
-    public String getTitle() {
-        return title;
+
+    private boolean isOwner(NsUser loginUser) {
+        return writer.equals(loginUser);
     }
 
-    public Question setTitle(String title) {
-        this.title = title;
-        return this;
+    private void delete() {
+        this.deleted = true;
     }
 
-    public String getContents() {
-        return contents;
-    }
-
-    public Question setContents(String contents) {
-        this.contents = contents;
-        return this;
-    }
-
-    public NsUser getWriter() {
-        return writer;
+    public boolean isDeleted() {
+        return deleted;
     }
 
     public void addAnswer(Answer answer) {
@@ -68,25 +73,8 @@ public class Question {
         answers.add(answer);
     }
 
-    public boolean isOwner(NsUser loginUser) {
-        return writer.equals(loginUser);
-    }
-
-    public Question setDeleted(boolean deleted) {
-        this.deleted = deleted;
-        return this;
-    }
-
-    public boolean isDeleted() {
-        return deleted;
-    }
-
-    public List<Answer> getAnswers() {
-        return answers;
-    }
-
     @Override
     public String toString() {
-        return "Question [id=" + getId() + ", title=" + title + ", contents=" + contents + ", writer=" + writer + "]";
+        return "Question [id=" + id + ", title=" + title + ", contents=" + contents + ", writer=" + writer + "]";
     }
 }

--- a/src/main/java/nextstep/qna/exception/CannotDeleteException.java
+++ b/src/main/java/nextstep/qna/exception/CannotDeleteException.java
@@ -1,4 +1,4 @@
-package nextstep.qna;
+package nextstep.qna.exception;
 
 public class CannotDeleteException extends Exception {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/nextstep/qna/exception/ForbiddenException.java
+++ b/src/main/java/nextstep/qna/exception/ForbiddenException.java
@@ -1,4 +1,4 @@
-package nextstep.qna;
+package nextstep.qna.exception;
 
 public class ForbiddenException extends RuntimeException{
     public ForbiddenException() {

--- a/src/main/java/nextstep/qna/exception/NotFoundException.java
+++ b/src/main/java/nextstep/qna/exception/NotFoundException.java
@@ -1,4 +1,4 @@
-package nextstep.qna;
+package nextstep.qna.exception;
 
 public class NotFoundException extends RuntimeException {
 }

--- a/src/main/java/nextstep/qna/exception/UnAuthenticationException.java
+++ b/src/main/java/nextstep/qna/exception/UnAuthenticationException.java
@@ -1,4 +1,4 @@
-package nextstep.qna;
+package nextstep.qna.exception;
 
 public class UnAuthenticationException extends Exception {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/nextstep/qna/exception/UnAuthorizedException.java
+++ b/src/main/java/nextstep/qna/exception/UnAuthorizedException.java
@@ -1,4 +1,4 @@
-package nextstep.qna;
+package nextstep.qna.exception;
 
 public class UnAuthorizedException extends RuntimeException {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -1,7 +1,7 @@
 package nextstep.qna.service;
 
-import nextstep.qna.CannotDeleteException;
-import nextstep.qna.NotFoundException;
+import nextstep.qna.exception.CannotDeleteException;
+import nextstep.qna.exception.NotFoundException;
 import nextstep.qna.domain.*;
 import nextstep.users.domain.NsUser;
 import org.springframework.stereotype.Service;

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -8,8 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Resource;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service("qnaService")
@@ -26,24 +24,7 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(NsUser loginUser, long questionId) throws CannotDeleteException {
         Question question = questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
-        deleteHistoryService.saveAll(deleteHistories);
+        List<DeleteHistory> deleteHistoryList = question.delete(loginUser);
+        deleteHistoryService.saveAll(deleteHistoryList);
     }
 }

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -24,7 +24,7 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(NsUser loginUser, long questionId) throws CannotDeleteException {
         Question question = questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
-        List<DeleteHistory> deleteHistoryList = question.delete(loginUser);
-        deleteHistoryService.saveAll(deleteHistoryList);
+        List<DeleteHistory> deleteHistories = question.delete(loginUser);
+        deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/main/java/nextstep/users/domain/NsUser.java
+++ b/src/main/java/nextstep/users/domain/NsUser.java
@@ -7,19 +7,12 @@ import java.util.Objects;
 
 public class NsUser {
     public static final GuestNsUser GUEST_USER = new GuestNsUser();
-
     private Long id;
-
     private String userId;
-
     private String password;
-
     private String name;
-
     private String email;
-
     private LocalDateTime createdAt;
-
     private LocalDateTime updatedAt;
 
     public NsUser() {
@@ -37,80 +30,6 @@ public class NsUser {
         this.email = email;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getUserId() {
-        return userId;
-    }
-
-    public NsUser setUserId(String userId) {
-        this.userId = userId;
-        return this;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public NsUser setPassword(String password) {
-        this.password = password;
-        return this;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public NsUser setName(String name) {
-        this.name = name;
-        return this;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public NsUser setEmail(String email) {
-        this.email = email;
-        return this;
-    }
-
-    public void update(NsUser loginUser, NsUser target) {
-        if (!matchUserId(loginUser.getUserId())) {
-            throw new UnAuthorizedException();
-        }
-
-        if (!matchPassword(target.getPassword())) {
-            throw new UnAuthorizedException();
-        }
-
-        this.name = target.name;
-        this.email = target.email;
-    }
-
-    public boolean matchUser(NsUser target) {
-        return matchUserId(target.getUserId());
-    }
-
-    private boolean matchUserId(String userId) {
-        return this.userId.equals(userId);
-    }
-
-    public boolean matchPassword(String targetPassword) {
-        return password.equals(targetPassword);
-    }
-
-    public boolean equalsNameAndEmail(NsUser target) {
-        if (Objects.isNull(target)) {
-            return false;
-        }
-
-        return name.equals(target.name) &&
-                email.equals(target.email);
     }
 
     public boolean isGuestUser() {

--- a/src/main/java/nextstep/users/domain/NsUser.java
+++ b/src/main/java/nextstep/users/domain/NsUser.java
@@ -1,9 +1,6 @@
 package nextstep.users.domain;
 
-import nextstep.qna.UnAuthorizedException;
-
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 public class NsUser {
     public static final GuestNsUser GUEST_USER = new GuestNsUser();

--- a/src/test/java/nextstep/qna/domain/AnswerTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswerTest.java
@@ -3,6 +3,5 @@ package nextstep.qna.domain;
 import nextstep.users.domain.NsUserTest;
 
 public class AnswerTest {
-    public static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
-    public static final Answer A2 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
 }

--- a/src/test/java/nextstep/qna/domain/AnswerTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswerTest.java
@@ -1,7 +1,47 @@
 package nextstep.qna.domain;
 
-import nextstep.users.domain.NsUserTest;
+import nextstep.qna.UnAuthorizedException;
+import nextstep.users.domain.NsUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AnswerTest {
 
+  private NsUser user;
+  private NsUser otherUser;
+  private long questionId;
+  private Question question;
+  private long answerId;
+  private Answer answer;
+
+  @BeforeEach
+  void setUp() {
+    user = new NsUser(1L, "userId", "password", "name", "email");
+    otherUser = new NsUser(2L, "otherId", "password", "name", "email");
+    questionId = 1L;
+    question = new Question(questionId, user, "title", "contents");
+    answerId = 1L;
+    answer = new Answer(answerId, user, question, "answer contents");
+  }
+
+  @Test
+  void delete_성공() {
+    DeleteHistory deleteHistory = answer.delete(user);
+
+    assertTrue(answer.isDeleted());
+    assertThat(deleteHistory).isEqualTo(
+        new DeleteHistory(ContentType.ANSWER, answerId, user));
+  }
+
+  @Test
+  void delete_다른_사용자가_삭제_시도() {
+    assertThatThrownBy(() -> answer.delete(otherUser))
+        .isInstanceOf(UnAuthorizedException.class)
+        .hasMessage("답변을 삭제할 권한이 없습니다.");
+  }
 }
+

--- a/src/test/java/nextstep/qna/domain/AnswerTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswerTest.java
@@ -1,47 +1,33 @@
 package nextstep.qna.domain;
 
-import nextstep.qna.UnAuthorizedException;
 import nextstep.users.domain.NsUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AnswerTest {
 
   private NsUser user;
-  private NsUser otherUser;
-  private long questionId;
-  private Question question;
   private long answerId;
   private Answer answer;
 
   @BeforeEach
   void setUp() {
     user = new NsUser(1L, "userId", "password", "name", "email");
-    otherUser = new NsUser(2L, "otherId", "password", "name", "email");
-    questionId = 1L;
-    question = new Question(questionId, user, "title", "contents");
+    Question question = new Question(1L, user, "title", "contents");
     answerId = 1L;
     answer = new Answer(answerId, user, question, "answer contents");
   }
 
   @Test
   void delete_성공() {
-    DeleteHistory deleteHistory = answer.delete(user);
+    DeleteHistory deleteHistory = answer.delete();
 
     assertTrue(answer.isDeleted());
     assertThat(deleteHistory).isEqualTo(
         new DeleteHistory(ContentType.ANSWER, answerId, user));
-  }
-
-  @Test
-  void delete_다른_사용자가_삭제_시도() {
-    assertThatThrownBy(() -> answer.delete(otherUser))
-        .isInstanceOf(UnAuthorizedException.class)
-        .hasMessage("답변을 삭제할 권한이 없습니다.");
   }
 }
 

--- a/src/test/java/nextstep/qna/domain/AnswersTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswersTest.java
@@ -1,0 +1,51 @@
+package nextstep.qna.domain;
+
+import nextstep.users.domain.NsUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnswersTest {
+
+  private NsUser user;
+  private NsUser otherUser;
+  private Question question;
+  private Answer answer1;
+  private Answer answer2;
+
+  @BeforeEach
+  public void setUp() {
+    user = new NsUser(1L, "userId", "password", "name", "email");
+    otherUser = new NsUser(2L, "otherId", "password", "name", "email");
+    question = new Question(1L, user, "title", "contents");
+    answer1 = new Answer(1L, user, question, "Answer1");
+    answer2 = new Answer(2L, user, question, "Answer2");
+  }
+
+  @Test
+  public void areAllAnswersSameWriter_모두_같은_작성자() {
+    Answers answers = new Answers(List.of(answer1, answer2));
+
+    assertThat(answers.areAllAnswersSameWriter(user)).isTrue();
+  }
+
+  @Test
+  public void areAllAnswersSameWriter_다른_작성자_포함() {
+    Answers answers = new Answers(List.of(answer1, new Answer(3L, otherUser, question, "Other Answer")));
+    assertThat(answers.areAllAnswersSameWriter(user)).isFalse();
+  }
+
+  @Test
+  public void delete_성공() {
+    Answers answers = new Answers(List.of(answer1, answer2));
+
+    List<DeleteHistory> deleteHistories = answers.delete();
+
+    assertThat(deleteHistories).hasSize(2);
+    assertThat(deleteHistories.get(0)).isEqualTo(new DeleteHistory(ContentType.ANSWER, 1L, user));
+    assertThat(deleteHistories.get(1)).isEqualTo(new DeleteHistory(ContentType.ANSWER, 2L, user));
+  }
+}

--- a/src/test/java/nextstep/qna/domain/AnswersTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswersTest.java
@@ -26,6 +26,12 @@ public class AnswersTest {
   }
 
   @Test
+  public void isEmpty_빈_답변여부_테스트() {
+    Answers answers = new Answers();
+    assertThat(answers.isEmpty()).isTrue();
+  }
+
+  @Test
   public void areAllAnswersSameWriter_모두_같은_작성자() {
     Answers answers = new Answers(List.of(answer1, answer2));
 
@@ -47,5 +53,7 @@ public class AnswersTest {
     assertThat(deleteHistories).hasSize(2);
     assertThat(deleteHistories.get(0)).isEqualTo(new DeleteHistory(ContentType.ANSWER, 1L, user));
     assertThat(deleteHistories.get(1)).isEqualTo(new DeleteHistory(ContentType.ANSWER, 2L, user));
+    assertThat(answer1.isDeleted()).isTrue();
+    assertThat(answer2.isDeleted()).isTrue();
   }
 }

--- a/src/test/java/nextstep/qna/domain/DeleteHistoryTest.java
+++ b/src/test/java/nextstep/qna/domain/DeleteHistoryTest.java
@@ -1,0 +1,16 @@
+package nextstep.qna.domain;
+
+import nextstep.users.domain.NsUser;
+import org.junit.jupiter.api.Test;
+
+public class DeleteHistoryTest {
+
+  @Test
+  void testEquals() {
+    NsUser user = new NsUser(1L, "user", "password", "name", "email");
+    DeleteHistory deleteHistory1 = new DeleteHistory(ContentType.QUESTION, 1L, user);
+    DeleteHistory deleteHistory2 = new DeleteHistory(ContentType.QUESTION, 1L, user);
+
+    assert deleteHistory1.equals(deleteHistory2);
+  }
+}

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -7,35 +7,58 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class QuestionTest {
 
     private NsUser user;
     private NsUser otherUser;
+    private long questionId;
     private Question question;
 
     @BeforeEach
     void setUp() {
+        questionId = 1L;
         user = new NsUser(1L, "user1", "password", "user1", "user1_email");
         otherUser = new NsUser(2L, "user2", "password", "user2", "user2_email");
-        question = new Question(1L, user, "title", "contents");
-        question.addAnswer(new Answer(1L, user, question, "answer1"));
+        question = new Question(questionId, user, "title", "contents");
     }
 
     @Test
-    void delete_성공() throws CannotDeleteException {
+    void delete_답변_없는_질문_삭제() throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = question.delete(user);
+
+        assertTrue(question.isDeleted());
+        assertEquals(1, deleteHistories.size());
+        assertEquals(new DeleteHistory(ContentType.QUESTION, questionId, user), deleteHistories.get(0));
+    }
+
+    @Test
+    void delete_답변_없는_질문_다른_사용자가_삭제_시도() {
+        assertThatThrownBy(() -> question.delete(otherUser))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage("질문을 삭제할 권한이 없습니다.");
+    }
+
+    @Test
+    void delete_답변이_있는_질문_같은_작성자_삭제() throws CannotDeleteException {
+        question.addAnswer(new Answer(1L, user, question, "answer1"));
         List<DeleteHistory> deleteHistories = question.delete(user);
 
         assertTrue(question.isDeleted());
         assertEquals(2, deleteHistories.size());
+        assertEquals(new DeleteHistory(ContentType.QUESTION, questionId, user), deleteHistories.get(0));
+        assertEquals(new DeleteHistory(ContentType.ANSWER, 1L, user), deleteHistories.get(1));
     }
 
     @Test
-    void delete_다른_사용자가_삭제_시도() {
+    void delete_답변이_있는_질문_다른_작성자_삭제() {
+        question.addAnswer(new Answer(1L, user, question, "answer1"));
         question.addAnswer(new Answer(2L, otherUser, question, "answer2"));
-        assertThrows(CannotDeleteException.class, () -> question.delete(otherUser));
+        assertThatThrownBy(() -> question.delete(user))
+                .isInstanceOf(CannotDeleteException.class)
+                .hasMessage("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
     }
 }

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -1,8 +1,41 @@
 package nextstep.qna.domain;
 
-import nextstep.users.domain.NsUserTest;
+import nextstep.qna.CannotDeleteException;
+import nextstep.users.domain.NsUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class QuestionTest {
-    public static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
-    public static final Question Q2 = new Question(NsUserTest.SANJIGI, "title2", "contents2");
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QuestionTest {
+
+    private NsUser user;
+    private NsUser otherUser;
+    private Question question;
+
+    @BeforeEach
+    void setUp() {
+        user = new NsUser(1L, "user1", "password", "user1", "user1_email");
+        otherUser = new NsUser(2L, "user2", "password", "user2", "user2_email");
+        question = new Question(1L, user, "title", "contents");
+        question.addAnswer(new Answer(1L, user, question, "answer1"));
+    }
+
+    @Test
+    void delete_성공() throws CannotDeleteException {
+        List<DeleteHistory> deleteHistories = question.delete(user);
+
+        assertTrue(question.isDeleted());
+        assertEquals(2, deleteHistories.size());
+    }
+
+    @Test
+    void delete_다른_사용자가_삭제_시도() {
+        question.addAnswer(new Answer(2L, otherUser, question, "answer2"));
+        assertThrows(CannotDeleteException.class, () -> question.delete(otherUser));
+    }
 }

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -1,6 +1,6 @@
 package nextstep.qna.domain;
 
-import nextstep.qna.CannotDeleteException;
+import nextstep.qna.exception.CannotDeleteException;
 import nextstep.users.domain.NsUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/nextstep/qna/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/qna/service/QnaServiceTest.java
@@ -24,10 +24,8 @@ import static org.mockito.Mockito.when;
 public class QnaServiceTest {
     @Mock
     private QuestionRepository questionRepository;
-
     @Mock
     private DeleteHistoryService deleteHistoryService;
-
     @InjectMocks
     private QnAService qnAService;
 
@@ -39,7 +37,7 @@ public class QnaServiceTest {
     private NsUser otherUser;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         writer = new NsUser(1L, "javajigi", "password", "name", "javajigi@slipp.net");
         otherUser = new NsUser(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
         questionId = 1L;

--- a/src/test/java/nextstep/qna/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/qna/service/QnaServiceTest.java
@@ -1,6 +1,6 @@
 package nextstep.qna.service;
 
-import nextstep.qna.CannotDeleteException;
+import nextstep.qna.exception.CannotDeleteException;
 import nextstep.qna.domain.*;
 import nextstep.users.domain.NsUser;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/nextstep/qna/service/QnaServiceTest.java
+++ b/src/test/java/nextstep/qna/service/QnaServiceTest.java
@@ -2,7 +2,7 @@ package nextstep.qna.service;
 
 import nextstep.qna.CannotDeleteException;
 import nextstep.qna.domain.*;
-import nextstep.users.domain.NsUserTest;
+import nextstep.users.domain.NsUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,22 +31,30 @@ public class QnaServiceTest {
     @InjectMocks
     private QnAService qnAService;
 
+    private Long questionId;
     private Question question;
+    private Long answerId;
     private Answer answer;
+    private NsUser writer;
+    private NsUser otherUser;
 
     @BeforeEach
     public void setUp() throws Exception {
-        question = new Question(1L, NsUserTest.JAVAJIGI, "title1", "contents1");
-        answer = new Answer(11L, NsUserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
+        writer = new NsUser(1L, "javajigi", "password", "name", "javajigi@slipp.net");
+        otherUser = new NsUser(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+        questionId = 1L;
+        question = new Question(questionId, writer, "title1", "contents1");
+        answerId = 1L;
+        answer = new Answer(answerId, writer, question, "Answers Contents1");
         question.addAnswer(answer);
     }
 
     @Test
     public void delete_성공() throws Exception {
-        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+        when(questionRepository.findById(questionId)).thenReturn(Optional.of(question));
 
         assertThat(question.isDeleted()).isFalse();
-        qnAService.deleteQuestion(NsUserTest.JAVAJIGI, question.getId());
+        qnAService.deleteQuestion(writer, questionId);
 
         assertThat(question.isDeleted()).isTrue();
         verifyDeleteHistories();
@@ -54,18 +62,18 @@ public class QnaServiceTest {
 
     @Test
     public void delete_다른_사람이_쓴_글() throws Exception {
-        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+        when(questionRepository.findById(questionId)).thenReturn(Optional.of(question));
 
         assertThatThrownBy(() -> {
-            qnAService.deleteQuestion(NsUserTest.SANJIGI, question.getId());
+            qnAService.deleteQuestion(otherUser, questionId);
         }).isInstanceOf(CannotDeleteException.class);
     }
 
     @Test
     public void delete_성공_질문자_답변자_같음() throws Exception {
-        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+        when(questionRepository.findById(questionId)).thenReturn(Optional.of(question));
 
-        qnAService.deleteQuestion(NsUserTest.JAVAJIGI, question.getId());
+        qnAService.deleteQuestion(writer, questionId);
 
         assertThat(question.isDeleted()).isTrue();
         assertThat(answer.isDeleted()).isTrue();
@@ -74,17 +82,17 @@ public class QnaServiceTest {
 
     @Test
     public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
-        when(questionRepository.findById(question.getId())).thenReturn(Optional.of(question));
+        when(questionRepository.findById(questionId)).thenReturn(Optional.of(question));
 
         assertThatThrownBy(() -> {
-            qnAService.deleteQuestion(NsUserTest.SANJIGI, question.getId());
+            qnAService.deleteQuestion(otherUser, questionId);
         }).isInstanceOf(CannotDeleteException.class);
     }
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+                new DeleteHistory(ContentType.QUESTION, questionId, writer, LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answerId, writer, LocalDateTime.now()));
         verify(deleteHistoryService).saveAll(deleteHistories);
     }
 }

--- a/src/test/java/nextstep/users/domain/NsUserTest.java
+++ b/src/test/java/nextstep/users/domain/NsUserTest.java
@@ -1,6 +1,36 @@
 package nextstep.users.domain;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class NsUserTest {
-    public static final NsUser JAVAJIGI = new NsUser(1L, "javajigi", "password", "name", "javajigi@slipp.net");
-    public static final NsUser SANJIGI = new NsUser(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+
+    private NsUser user;
+    private NsUser guestUser;
+
+    @BeforeEach
+    public void setUp() {
+        user = new NsUser(1L, "userId", "password", "name", "email");
+        guestUser = NsUser.GUEST_USER;
+    }
+
+    @Test
+    public void 일반_사용자_확인() {
+        assertThat(user.isGuestUser()).isFalse();
+    }
+
+    @Test
+    public void 게스트_사용자_확인() {
+        assertThat(guestUser.isGuestUser()).isTrue();
+    }
+
+    @Test
+    public void NsUser_생성_및_확인() {
+        NsUser newUser = new NsUser(2L, "newUserId", "newPassword", "newName", "newEmail");
+
+        assertThat(newUser.toString()).contains("newUserId", "newName", "newEmail");
+        assertThat(newUser.isGuestUser()).isFalse();
+    }
 }


### PR DESCRIPTION
안녕하세요 🤓
1단계 구현 완료하여 PR 드립니다!
마지막 단계까지 잘 부탁드립니닷 🙇‍♀️

📌 리팩터링 내용

1. `QnaService`의 비즈니스 로직을 도메인 모델로 이동
  - 기존 `QnaService`의 `deleteQuestion()` 메서드가 너무 많은 비즈니스 로직을 포함하고 있어 이를 도메인 모델로 분리하였습니다.
  - `Question`, `Answers`, `Answer`, `DeleteHistory` 도메인 클래스로 기능을 재구성하였습니다.
  - `Question`이 가지고 있는 `List<Answer>`를 일급컬렉션인 `Answers`로 한번 감쌌습니다.

2. Question 에서 답변 삭제 로직을 모두 담당하도록 하여 책임을 명확히 하였습니다.
  - delete() 메서드 내부에서 createDeleteHistory() 를 호출하도록 하여 삭제 기록 생성이 항상 보장되도록 구현하였습니다.

🧐 고민 포인트

- `Question`과 `Answer`의 `delete` 메서드가 `DeleteHistory` 객체를 반환하는 것이 어색하다고 느꼈는데요ㅠ
- 단순히 삭제 로직을 수행하는 메서드가 데이터를 반환하는 것이 좀 어색하다는 생각이 계속 들긴 했습니다...!
- 그런데 만약 `delete` 메서드와 `DeleteHistory` 생성을 별도로 처리하면, 사용자가 `delete` 메서드를 호출할 때 `DeleteHistory` 생성을 빠뜨릴 수 있다는 문제(?)점이 있을 것 같아서, `DeleteHistory` 생성이 보장을 위해 `delete` 메서드 안에 구현하긴 했습니다..!
 