### PR TITLE
step1

### DIFF
--- a/src/main/java/nextstep/qna/domain/Answer.java
+++ b/src/main/java/nextstep/qna/domain/Answer.java
@@ -1,5 +1,6 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.qna.NotFoundException;
 import nextstep.qna.UnAuthorizedException;
 import nextstep.users.domain.NsUser;
@@ -56,6 +57,15 @@ public class Answer {
         return deleted;
     }
 
+    public Answer delete(NsUser user) throws CannotDeleteException {
+        if (isOwner(user)) {
+            deleted = true;
+            return this;
+        }
+        throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+    }
+
+
     public boolean isOwner(NsUser writer) {
         return this.writer.equals(writer);
     }
@@ -71,6 +81,8 @@ public class Answer {
     public void toQuestion(Question question) {
         this.question = question;
     }
+
+
 
     @Override
     public String toString() {

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -1,0 +1,39 @@
+package nextstep.qna.domain;
+
+import nextstep.users.domain.NsUser;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Answers {
+    private final List<Answer> answers = new ArrayList<>();
+
+    public void addAnswer(Answer answer) {
+        answers.add(answer);
+    }
+
+    public boolean hasAnswerFromOtherUser(NsUser user) {
+        for (Answer answer : answers) {
+            if (!answer.isOwner(user)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void delete() {
+        for (Answer answer : answers) {
+            answer.setDeleted(true);
+        }
+    }
+
+    public List<DeleteHistory> collectDeleteHistory() {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        for (Answer answer : answers) {
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+        }
+        return deleteHistories;
+    }
+}
+

--- a/src/main/java/nextstep/qna/domain/Answers.java
+++ b/src/main/java/nextstep/qna/domain/Answers.java
@@ -1,8 +1,8 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUser;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,16 +22,11 @@ public class Answers {
         return false;
     }
 
-    public void delete() {
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-        }
-    }
-
-    public List<DeleteHistory> collectDeleteHistory() {
+    public List<DeleteHistory> deleteAllAnswers(NsUser loginUser) throws CannotDeleteException {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         for (Answer answer : answers) {
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
+            answer.delete(loginUser);
+            deleteHistories.add(DeleteHistory.ofAnswer(answer.getId(), answer.getWriter()));
         }
         return deleteHistories;
     }

--- a/src/main/java/nextstep/qna/domain/DeleteHistory.java
+++ b/src/main/java/nextstep/qna/domain/DeleteHistory.java
@@ -26,6 +26,14 @@ public class DeleteHistory {
         this.createdDate = createdDate;
     }
 
+    public static DeleteHistory ofQuestion(Long contentId, NsUser deletedBy) {
+        return new DeleteHistory(ContentType.QUESTION, contentId, deletedBy, LocalDateTime.now());
+    }
+
+    public static DeleteHistory ofAnswer(Long contentId, NsUser deletedBy) {
+        return new DeleteHistory(ContentType.ANSWER, contentId, deletedBy, LocalDateTime.now());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -1,5 +1,6 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUser;
 
 import java.time.LocalDateTime;
@@ -15,7 +16,7 @@ public class Question {
 
     private NsUser writer;
 
-    private List<Answer> answers = new ArrayList<>();
+    private Answers answers;
 
     private boolean deleted = false;
 
@@ -35,6 +36,7 @@ public class Question {
         this.writer = writer;
         this.title = title;
         this.contents = contents;
+        this.answers = new Answers();
     }
 
     public Long getId() {
@@ -65,7 +67,7 @@ public class Question {
 
     public void addAnswer(Answer answer) {
         answer.toQuestion(this);
-        answers.add(answer);
+        answers.addAnswer(answer);
     }
 
     public boolean isOwner(NsUser loginUser) {
@@ -81,8 +83,22 @@ public class Question {
         return deleted;
     }
 
-    public List<Answer> getAnswers() {
-        return answers;
+    public void delete(NsUser loginUser) throws CannotDeleteException {
+        if (!isOwner(loginUser)) {
+            throw new CannotDeleteException("질문 작성자 아닌 사람은 삭제 권한 없음");
+        }
+        if (answers.hasAnswerFromOtherUser(writer)) {
+            throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
+        }
+        deleted = true;
+        answers.delete();
+    }
+
+    public List<DeleteHistory> collectDeleteHistory() {
+        List<DeleteHistory> deleteHistories = new ArrayList<>();
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
+        deleteHistories.addAll(answers.collectDeleteHistory());
+        return deleteHistories;
     }
 
     @Override

--- a/src/main/java/nextstep/qna/domain/Question.java
+++ b/src/main/java/nextstep/qna/domain/Question.java
@@ -83,7 +83,7 @@ public class Question {
         return deleted;
     }
 
-    public void delete(NsUser loginUser) throws CannotDeleteException {
+    public List<DeleteHistory> delete(NsUser loginUser) throws CannotDeleteException {
         if (!isOwner(loginUser)) {
             throw new CannotDeleteException("질문 작성자 아닌 사람은 삭제 권한 없음");
         }
@@ -91,14 +91,11 @@ public class Question {
             throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
         }
         deleted = true;
-        answers.delete();
-    }
-
-    public List<DeleteHistory> collectDeleteHistory() {
         List<DeleteHistory> deleteHistories = new ArrayList<>();
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, id, writer, LocalDateTime.now()));
-        deleteHistories.addAll(answers.collectDeleteHistory());
-        return deleteHistories;
+        deleteHistories.add(DeleteHistory.ofQuestion(id, loginUser));
+        List<DeleteHistory> deletedAnswerHistory = answers.deleteAllAnswers(loginUser);
+        deleteHistories.addAll(deletedAnswerHistory);
+        return  deleteHistories;
     }
 
     @Override

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -24,8 +24,7 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(NsUser loginUser, long questionId) throws CannotDeleteException {
         Question question = questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
-        question.delete(loginUser);
-        List<DeleteHistory> deleteHistories = question.collectDeleteHistory();
+        List<DeleteHistory> deleteHistories = question.delete(loginUser);
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/main/java/nextstep/qna/service/QnAService.java
+++ b/src/main/java/nextstep/qna/service/QnAService.java
@@ -8,8 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Resource;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service("qnaService")
@@ -26,24 +24,8 @@ public class QnAService {
     @Transactional
     public void deleteQuestion(NsUser loginUser, long questionId) throws CannotDeleteException {
         Question question = questionRepository.findById(questionId).orElseThrow(NotFoundException::new);
-        if (!question.isOwner(loginUser)) {
-            throw new CannotDeleteException("질문을 삭제할 권한이 없습니다.");
-        }
-
-        List<Answer> answers = question.getAnswers();
-        for (Answer answer : answers) {
-            if (!answer.isOwner(loginUser)) {
-                throw new CannotDeleteException("다른 사람이 쓴 답변이 있어 삭제할 수 없습니다.");
-            }
-        }
-
-        List<DeleteHistory> deleteHistories = new ArrayList<>();
-        question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
-        for (Answer answer : answers) {
-            answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
-        }
+        question.delete(loginUser);
+        List<DeleteHistory> deleteHistories = question.collectDeleteHistory();
         deleteHistoryService.saveAll(deleteHistories);
     }
 }

--- a/src/test/java/nextstep/qna/domain/AnswerTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswerTest.java
@@ -1,10 +1,12 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUserTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AnswerTest {
     public static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
@@ -18,12 +20,15 @@ public class AnswerTest {
     }
 
     @Test
-    public void testAnswer() {
-        assertThat(answers.hasAnswerFromOtherUser(NsUserTest.JAVAJIGI)).isFalse();
+    public void testAnswer() throws CannotDeleteException {
+        Answer answer = A1.delete(NsUserTest.JAVAJIGI);
+        assertThat(answer).isEqualTo(A1);
+        assertThat(answer.isDeleted()).isTrue();
     }
 
     @Test
     public void testAnswerFromOtherUser() {
-        assertThat(answers.hasAnswerFromOtherUser(NsUserTest.SANJIGI)).isTrue();
+        assertThatThrownBy(() -> A2.delete(NsUserTest.JAVAJIGI))
+                .isInstanceOf(CannotDeleteException.class);
     }
 }

--- a/src/test/java/nextstep/qna/domain/AnswerTest.java
+++ b/src/test/java/nextstep/qna/domain/AnswerTest.java
@@ -1,8 +1,29 @@
 package nextstep.qna.domain;
 
 import nextstep.users.domain.NsUserTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnswerTest {
     public static final Answer A1 = new Answer(NsUserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(NsUserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+    public Answers answers;
+
+    @BeforeEach
+    public void setUp() {
+        this.answers = new Answers();
+        answers.addAnswer(A1);
+    }
+
+    @Test
+    public void testAnswer() {
+        assertThat(answers.hasAnswerFromOtherUser(NsUserTest.JAVAJIGI)).isFalse();
+    }
+
+    @Test
+    public void testAnswerFromOtherUser() {
+        assertThat(answers.hasAnswerFromOtherUser(NsUserTest.SANJIGI)).isTrue();
+    }
 }

--- a/src/test/java/nextstep/qna/domain/QuestionTest.java
+++ b/src/test/java/nextstep/qna/domain/QuestionTest.java
@@ -1,8 +1,25 @@
 package nextstep.qna.domain;
 
+import nextstep.qna.CannotDeleteException;
 import nextstep.users.domain.NsUserTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class QuestionTest {
     public static final Question Q1 = new Question(NsUserTest.JAVAJIGI, "title1", "contents1");
     public static final Question Q2 = new Question(NsUserTest.SANJIGI, "title2", "contents2");
+
+    @Test
+    public void delete_by_writer() throws CannotDeleteException {
+        Q1.delete(NsUserTest.JAVAJIGI);
+        assertThat(Q1.isDeleted()).isTrue();
+    }
+
+    @Test
+    public void delete_by_non_writer() {
+        assertThatThrownBy(() -> Q1.delete(NsUserTest.SANJIGI))
+                .isInstanceOf(CannotDeleteException.class);
+    }
 }


### PR DESCRIPTION

- Question 객체 내에 answers를 일급 객체로 변경
- question 삭제 가능 여부 체크 로직을 question 내부에 넣음
- deleteHistory 리스트 생성을 delete 발생 이후 question 객체 내부에서 생성해서 qnaService로 반환하도록함

의문:
qnaService에서 get을 통해 answers를 가져와 qnaService.deleteQuestion 상에서 추가해도 좋을거같은데 question.collectDeleteHistory -> answers.collectDeleteHistory -> 반환 -> 반환 을 통하려하니 좀 복잡해지는게 아닌가 생각했습니다.